### PR TITLE
Fixed the achievement "No Perks? No Problem"

### DIFF
--- a/source/server/rounds.qc
+++ b/source/server/rounds.qc
@@ -155,13 +155,14 @@ void() EndRound =
 		players = find(world, classname, "player");
 
 		while(players != world) {
-			if (players.ach_tracker_npnp == 0) {
-				GiveAchievement(5, players);
-			}
 			if (players.ach_tracker_abst == 0) {
 				GiveAchievement(8, players);
 			}
-			players.ach_tracker_npnp = 0;
+			if (rounds >= 16) {
+				if (players.ach_tracker_npnp == 0) {
+					GiveAchievement(5, players);
+				}
+			}
 			players = find(players, classname, "player");
 		}
 	}


### PR DESCRIPTION
The achievement should trigger at round 16 at the earliest after the description "Survive an entire Round without Perks past Round 15 or higher".

The achievement triggers at the end of round 12, regardless if you bought perks or not.

I added a line to check if it's after round 15 and removed the line "players.ach_tracker_npnp = 0;" which reset the count of drank perks, so it triggers correctly.