### PR TITLE
Fixed a crash when shooting a teddy with the Wunderwaffe DG-2 / Wunderwaffe DG-3 JZ

### DIFF
--- a/source/server/weapons/tesla.qc
+++ b/source/server/weapons/tesla.qc
@@ -68,6 +68,17 @@ void(entity hit_ent, entity arc_parent, entity arc_owner, float arc_num, float d
 	if (hit_ent.rarm)
 		setmodel(hit_ent.rarm, "");
 
+	if(hit_ent.classname == "item_radio" || hit_ent.classname == "teddy_spawn")
+	{
+		entity oldself;
+		oldself  = self;
+		self = hit_ent;
+		self.th_die();
+		self = oldself;
+		return;
+	}
+
+
     hit_ent.velocity.x = 0;
     hit_ent.velocity.y = 0;
 

--- a/source/server/weapons/tesla.qc
+++ b/source/server/weapons/tesla.qc
@@ -91,12 +91,15 @@ void(entity hit_ent, entity arc_parent, entity arc_owner, float arc_num, float d
 	// hit_ent.classname = "wunder";
 
     if(arc_owner != world) {
-        arc_owner.tesla_n_kills += 1;
+	//Only add kills and money if a zombie was hit
+	if(hit_ent.classname == "ai_zombie") {
+        	arc_owner.tesla_n_kills += 1;
         
-        // 50 points for waffe kills
-        if(arc_owner.classname == "player") {
-            arc_owner.kills += 1;
-            addmoney(arc_owner, 50, true);
+		// 50 points for waffe kills
+		if(arc_owner.classname == "player") {
+            		arc_owner.kills += 1;
+            		addmoney(arc_owner, 50, true);
+		}
         }
     }
 


### PR DESCRIPTION
I added the check from the "weapon_core.qc", which checks for radios and teddies, so the game counts them normally and doesn't crash.
Also fixed that when shooting radios and barrels with the Wunderwaffe the game would count them as kills and add money to the player.