### PR TITLE
Remove if statement adding points for explosive kills

### DIFF
--- a/source/server/damage.qc
+++ b/source/server/damage.qc
@@ -474,11 +474,6 @@ void(entity victim, entity attacker, float damage, float d_style) DamageHandler 
 				makeCrawler(victim);
 				GiveAchievement(3, attacker);
 			}
-				
-			if (victim.health <= 0)
-				Player_AddScore(attacker, 60, true);
-			else
-				Player_AddScore(attacker, 10, true);
 		}
 
 		if (victim.health <= 0 || instakill_finished > time) {


### PR DESCRIPTION
DieHandler was adding these points anyway, and the amount it adds for grenades is not correct. It was also causing crashes when explosive barrel props killed zombies, because it wasn't properly guarded.

Fixes: https://github.com/nzp-team/nzportable/issues/783