### PR TITLE
CLIENT: Set setsensitivityscaler to 0 while paused

### DIFF
--- a/source/client/main.qc
+++ b/source/client/main.qc
@@ -663,7 +663,11 @@ noref void(float width, float height, float menushown) CSQC_UpdateView =
 	setviewprop(VF_DRAWENGINESBAR, 0);	
 	setviewprop(VF_DRAWCROSSHAIR, 0);
 
-	setsensitivityscaler((1 + SCALE_CONSTANT * getstatf(STAT_VIEWZOOM)) / (1 + SCALE_CONSTANT));
+	if (in_menu == MENU_PAUSE)
+		setsensitivityscaler(0);
+	else
+		setsensitivityscaler((1 + SCALE_CONSTANT * getstatf(STAT_VIEWZOOM)) / (1 + SCALE_CONSTANT));
+
 	setviewprop(VF_AFOV, autocvar(fov,90)*getstatf(STAT_VIEWZOOM));
 
 	cvar_set("r_viewmodel_fov", ftos(cvar("r_viewmodel_default_fov")*getstatf(STAT_VIEWZOOM)));


### PR DESCRIPTION
This is to stop the controller stick from being able to turn the camera while paused.

This also requires a separate FTE engine change, but should still be fine to merge here.