### PR TITLE
SERVER: Fix Pack-a-Punch animation not working on certain platforms

### DIFF
--- a/source/server/entities/pack_a_punch.qc
+++ b/source/server/entities/pack_a_punch.qc
@@ -231,6 +231,7 @@ void(entity pap, entity buyer) PAP_UpgradeWeapon =
 	pap.weapon = self.weapon;
 
 	Weapon_RemoveWeapon(0);
+	W_PutOutHack(); //Swap Weapon
 	W_HideCrosshair(self);
 	Set_W_Frame (0, 39, 2.0, 0, 0, W_PutOutHack, "models/machines/v_pap.mdl", true, S_BOTH, true);
 	self.weapon2model = "";


### PR DESCRIPTION
Weapon was being removed and not swapped until after attempting the animation. Weapon now gets removed, swapped to secondary, animation carries out and weapons get swapped again after.