### PR TITLE
MENU: Co-Op Menus WIP + Server Browser

### DIFF
--- a/progs/menu.src
+++ b/progs/menu.src
@@ -23,6 +23,7 @@ menu_gpad.qc     // Gamepad Menu
 menu_bind.qc     // Bindings Menu
 menu_cred.qc     // Credits Menu
 menu_load.qc     // Loading Screen
+menu_coop.qc     // Co-op Menu
 
 main.qc
 #endlist

--- a/progs/menu.src
+++ b/progs/menu.src
@@ -1,5 +1,3 @@
-../source/menu/main.qc
-
 #pragma noref 1
 #pragma target fte_5768
 #pragma progs_dat "../build/fte/menu.dat"

--- a/source/client/defs/fte.qc
+++ b/source/client/defs/fte.qc
@@ -12,7 +12,7 @@ pr_dumpplatform -O csdefs -Tcs -Ffte
 #pragma warning error Q208 /*system crc unknown. Compatibility goes out of the window if you disable this.*/
 #pragma warning enable F301 /*non-utf-8 strings. Think of the foreigners! Also think of text editors that insist on screwing up your char encodings.*/
 #pragma warning enable F302 /*uninitialised locals. They usually default to 0 in qc (except in recursive functions), but its still probably a bug*/
-#pragma target FTE
+#pragma target fte_5768
 #define FTEDEP DEP
 #ifndef CSQC
 	#define CSQC

--- a/source/menu/defs/fte.qc
+++ b/source/menu/defs/fte.qc
@@ -21,7 +21,7 @@ Available options:
 #pragma warning disable F211 /*system crc outdated (eg: dp's csqc)*/
 #pragma warning enable F301 /*non-utf-8 strings*/
 #pragma warning enable F302 /*uninitialised locals*/
-#pragma target FTE_5768
+#pragma target fte_5768
 #ifndef MENU
 #define MENU
 #endif

--- a/source/menu/defs/menu_defs.qc
+++ b/source/menu/defs/menu_defs.qc
@@ -38,6 +38,13 @@ enum {
     MENU_MAIN,
     MENU_SOLO,
     MENU_SOLOUSER,
+    MENU_COOP,
+    MENU_COOPJOIN,
+    MENU_COOPBROWSE,
+    MENU_COOPDIRECT,
+    MENU_COOPCREATE,
+    MENU_COOPSTOCK,
+    MENU_COOPUSER,
     MENU_OPTIONS,
     MENU_VIDEO,
     MENU_AUDIO,
@@ -56,6 +63,11 @@ void(float type) Menu_PlaySound;
 
 void() Menu_Main;
 void() Menu_Maps;
+void() Menu_Coop;
+void() Menu_Coop_Join;
+void() Menu_Coop_Browse;
+void() Menu_Coop_Direct;
+void() Menu_Coop_Create;
 void() Menu_Credits;
 
 #else

--- a/source/menu/defs/menu_defs.qc
+++ b/source/menu/defs/menu_defs.qc
@@ -87,6 +87,19 @@ void() Menu_Bindings;
 
 string(string prev_id) Menu_Main_GetNextButton;
 string(string next_id) Menu_Main_GetPreviousButton;
+
+string(string next_id) Menu_Coop_Browse_GetNextButton;
+string(string next_id) Menu_Coop_Direct_GetNextButton;
+string(string next_id) Menu_Coop_Join_GetNextButton;
+string(string next_id) Menu_Coop_Create_GetNextButton;
+string(string next_id) Menu_Coop_GetNextButton;
+
+string(string next_id) Menu_Coop_Browse_GetPreviousButton;
+string(string next_id) Menu_Coop_Direct_GetPreviousButton;
+string(string next_id) Menu_Coop_Join_GetPreviousButton;
+string(string next_id) Menu_Coop_Create_GetPreviousButton;
+string(string next_id) Menu_Coop_GetPreviousButton;
+
 string(string prev_id) Menu_Maps_GetNextButton;
 string(string next_id) Menu_Maps_GetPreviousButton;
 

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -608,15 +608,15 @@ void(string id, float order, __inout string text, __inout float cursor) Menu_Pas
 	draw_text_input(id, pos, size, safe, cursor);
 };
 
-static string str2ascii(string s)
+static string(string s) str2ascii =
 {
 	for (int i = 0; i < strlen(s); i++)
 	{
-		if (str2chr(s, i) < 32 || str2chr(s, i) > 126)
+		if (s[i] < 32 || s[i] > 126)
 			s[i] = 63; // question mark
 	}
 	return s;
-}
+};
 
 //
 // Menu_ServerList(id, pos, size, scrollofs, num_servers)

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -31,7 +31,7 @@ void(string id, vector pos, vector size, float maxlen, __inout string text, __in
 	vector basecolor = sui_is_hovered(id) ? MENU_BG_DARK + MENU_HIGHLIGHT * 0.08 : MENU_BG_DARK; 
 	sui_fill([0, 0], size, basecolor, 0.6, 0);
 	
-	sui_text_input(id, [0, 0], size, text, cursor);
+	sui_text_input(id, [0, 0], size, maxlen, text, cursor);
 
 	sui_cap_input_length(maxlen, text, cursor);
 	
@@ -554,13 +554,20 @@ void(float order, vector minmaxsteps, string cvar_s, float is_int, float no_text
 
 static void(string id, vector pos, vector size, __inout string text, __inout float cursor) handle_text_input =
 {
+	float maxlen = 0;
+
+	if (getTextWidth(text, MENU_TEXT_SMALL.x) + 18 >= size.x)
+		maxlen = strlen(text);
+	else
+		maxlen = 128;
+
 	sui_action_element(pos, size, id, sui_noop);
 	if (sui_is_clicked(id)) cursor = strlen(text);
 	if (sui_is_hovered(id))
 	{
 		float char = 0;
 		float scan = 0;
-		while(sui_get_input(char, scan)) sui_handle_text_input(char, scan, text, cursor);
+		while(sui_get_input(char, scan)) sui_handle_text_input(char, scan, maxlen, text, cursor);
 	}
 };
 
@@ -571,8 +578,9 @@ static void(string id, vector pos, vector size, string text, float cursor) draw_
 	sui_border_box([0, 0], size, 2, [0.2, 0.2, 0.2], 0.3, 0);
 	sui_set_align([SUI_ALIGN_START, SUI_ALIGN_CENTER]);
 	sui_text([6, 0], MENU_TEXT_SMALL, text, MENU_TEXT_1, 1, 0);
+	float cursor_x = getTextWidth(substring(text, 0, cursor), MENU_TEXT_SMALL.x);
 	if (sui_is_hovered(id))
-		sui_text([6, 0] + [cursor * 10, 0], MENU_TEXT_SMALL, "|", MENU_TEXT_1 + MENU_HIGHLIGHT, 1, 0);
+		sui_text([6 + cursor_x, 0], MENU_TEXT_SMALL, "|", [1.0, 0.25, 0.25], 1, 0);
 	sui_pop_frame();
 };
 

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -622,7 +622,7 @@ void(string id, vector pos, vector size, __inout vector scrollofs, float num_ser
 
 		// bg
 		vector bpos = [0, 0];
-		vector bsize = [rowsize.x / 3, rowsize.y];
+		vector bsize = [(rowsize.x / 8) * 5, rowsize.y];
 		sui_fill(bpos, rowsize, [0.25, 0.25, 0.25], 0.5, 0);
 
 		// name
@@ -630,11 +630,12 @@ void(string id, vector pos, vector size, __inout vector scrollofs, float num_ser
 		sui_text(bpos + [8, 0], MENU_TEXT_SMALL, gethostcachestring(gethostcacheindexforkey("name"), index), MENU_TEXT_1, 1, 0);
 
 		// map
-		bpos.x = size.x / 3;
+		bsize.x = (rowsize.x / 8);
+		bpos.x = bsize.x * 5;
 		sui_text(bpos + [8, 0], MENU_TEXT_SMALL, gethostcachestring(gethostcacheindexforkey("map"), index), MENU_TEXT_1, 1, 0);
 
 		// players
-		bpos.x *= 2;
+		bpos.x = bsize.x * 7;
 		string s = sprintf("%d/%d",
 			stof(gethostcachestring(gethostcacheindexforkey("numhumans"), index)),
 			stof(gethostcachestring(gethostcacheindexforkey("maxplayers"), index))

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -608,6 +608,16 @@ void(string id, float order, __inout string text, __inout float cursor) Menu_Pas
 	draw_text_input(id, pos, size, safe, cursor);
 };
 
+static string str2ascii(string s)
+{
+	for (int i = 0; i < strlen(s); i++)
+	{
+		if (str2chr(s, i) < 32 || str2chr(s, i) > 126)
+			s[i] = 63; // question mark
+	}
+	return s;
+}
+
 //
 // Menu_ServerList(id, pos, size, scrollofs, num_servers)
 // Draw the master server list
@@ -630,7 +640,7 @@ void(string id, vector pos, vector size, __inout vector scrollofs, float num_ser
 
 		// name
 		sui_fill(bpos, bsize, [0.25, 0.25, 0.25], 0.5, 0);
-		sui_text(bpos + [8, 0], MENU_TEXT_SMALL, gethostcachestring(gethostcacheindexforkey("name"), index), MENU_TEXT_1, 1, 0);
+		sui_text(bpos + [8, 0], MENU_TEXT_SMALL, str2ascii(gethostcachestring(gethostcacheindexforkey("name"), index)), MENU_TEXT_1, 1, 0);
 
 		// map
 		bsize.x = (rowsize.x / 8);

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -564,13 +564,15 @@ static void(string id, vector pos, vector size, __inout string text, __inout flo
 	}
 };
 
-static void(vector pos, vector size, string text) draw_text_input =
+static void(string id, vector pos, vector size, string text, float cursor) draw_text_input =
 {
 	sui_push_frame(pos - [6, 5], size);
 	sui_fill([0, 0], size, [0, 0, 0], 1.0, 0);
 	sui_border_box([0, 0], size, 2, [0.2, 0.2, 0.2], 0.3, 0);
 	sui_set_align([SUI_ALIGN_START, SUI_ALIGN_CENTER]);
 	sui_text([6, 0], MENU_TEXT_SMALL, text, MENU_TEXT_1, 1, 0);
+	if (sui_is_hovered(id))
+		sui_text([6, 0] + [cursor * 10, 0], MENU_TEXT_SMALL, "|", MENU_TEXT_1 + MENU_HIGHLIGHT, 1, 0);
 	sui_pop_frame();
 };
 
@@ -585,7 +587,7 @@ void(string id, float order, __inout string text, __inout float cursor) Menu_Tex
 
 	handle_text_input(id, pos, size, text, cursor);
 
-	draw_text_input(pos, size, text);
+	draw_text_input(id, pos, size, text, cursor);
 };
 
 //
@@ -603,7 +605,7 @@ void(string id, float order, __inout string text, __inout float cursor) Menu_Pas
 
 	handle_text_input(id, pos, size, text, cursor);
 
-	draw_text_input(pos, size, safe);
+	draw_text_input(id, pos, size, safe, cursor);
 };
 
 //

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -647,18 +647,18 @@ void(string id, vector pos, vector size, __inout vector scrollofs, float num_ser
 		// bg
 		vector bpos = [0, 0];
 		vector bsize = [(rowsize.x / 8) * 5, rowsize.y];
-		sui_fill(bpos, rowsize, [0.25, 0.25, 0.25], 0.5, 0);
+		sui_fill(bpos, rowsize, [0.25, 0.1, 0.1], 0.5, 0);
 
 		// hovered bg
 		if (sui_is_hovered(listitem_id))
-			sui_fill(bpos, rowsize, [0.25, 0.25, 0.25], 0.5, 0);
+			sui_fill(bpos, rowsize, [0.25, 0.1, 0.1], 0.5, 0);
 
 		// do it
 		if (sui_is_clicked(listitem_id))
 			localcmd("connect ", gethostcachestring(gethostcacheindexforkey("cname"), index), "\n");
 
 		// name
-		sui_fill(bpos, bsize, [0.25, 0.25, 0.25], 0.5, 0);
+		sui_fill(bpos, bsize, [0.25, 0.1, 0.1], 0.5, 0);
 		sui_text(bpos + [8, 0], MENU_TEXT_SMALL, str2ascii(gethostcachestring(gethostcacheindexforkey("name"), index)), MENU_TEXT_1, 1, 0);
 
 		// map
@@ -672,8 +672,13 @@ void(string id, vector pos, vector size, __inout vector scrollofs, float num_ser
 			stof(gethostcachestring(gethostcacheindexforkey("numhumans"), index)),
 			stof(gethostcachestring(gethostcacheindexforkey("maxplayers"), index))
 		);
-		sui_fill(bpos, bsize, [0.25, 0.25, 0.25], 0.5, 0);
+		sui_fill(bpos, bsize, [0.25, 0.1, 0.1], 0.5, 0);
 		sui_text(bpos + [8, 0], MENU_TEXT_SMALL, s, MENU_TEXT_1, 1, 0);
+
+		// hovered border
+		bpos = [0, 0];
+		if (sui_is_hovered(listitem_id))
+			sui_border_box(bpos, rowsize, 1, [0.4, 0.4, 0], 1, 0);
 
 		sui_pop_frame();
 	}

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -32,6 +32,8 @@ void(string id, vector pos, vector size, float maxlen, __inout string text, __in
 	sui_fill([0, 0], size, basecolor, 0.6, 0);
 	
 	sui_text_input(id, [0, 0], size, text, cursor);
+
+	sui_cap_input_length(maxlen, text, cursor);
 	
 	sui_set_align([SUI_ALIGN_START, SUI_ALIGN_CENTER]);
 	float focused = sui_is_last_clicked(id);
@@ -550,6 +552,101 @@ void(float order, vector minmaxsteps, string cvar_s, float is_int, float no_text
 	}
 };
 
+static void(string id, vector pos, vector size, __inout string text, __inout float cursor) handle_text_input =
+{
+	sui_action_element(pos, size, id, sui_noop);
+	if (sui_is_clicked(id)) cursor = strlen(text);
+	if (sui_is_hovered(id))
+	{
+		float char = 0;
+		float scan = 0;
+		while(sui_get_input(char, scan)) sui_handle_text_input(char, scan, text, cursor);
+	}
+};
+
+static void(vector pos, vector size, string text) draw_text_input =
+{
+	sui_push_frame(pos, size);
+	sui_fill([0, 0], size, [0.5, 0.1, 0.1], 1.0, 0);
+	sui_set_align([SUI_ALIGN_START, SUI_ALIGN_CENTER]);
+	sui_text([6, 0], MENU_TEXT_SMALL, text, MENU_TEXT_1, 1, 0);
+	sui_pop_frame();
+};
+
+//
+// Menu_TextInput(id, order, text, cursor)
+// Draws a Text Input box at the given order position
+//
+void(string id, float order, __inout string text, __inout float cursor) Menu_TextInput =
+{
+	vector pos = [320, 50 + (order * 25)];
+	vector size = [240, 16];
+
+	handle_text_input(id, pos, size, text, cursor);
+
+	draw_text_input(pos, size, text);
+};
+
+//
+// Menu_PasswordInput(id, order, text, cursor)
+// Draws a Text Input box at the given order position (blocked out with asterisks)
+//
+void(string id, float order, __inout string text, __inout float cursor) Menu_PasswordInput =
+{
+	vector pos = [320, 50 + (order * 25)];
+	vector size = [240, 16];
+	string safe = "";
+
+	for (int i = 0; i < strlen(text); i++)
+		safe = sprintf("%s%s", safe, "*");
+
+	handle_text_input(id, pos, size, text, cursor);
+
+	draw_text_input(pos, size, safe);
+};
+
+//
+// Menu_ServerList(id, pos, size, scrollofs, num_servers)
+// Draw the master server list
+//
+void(string id, vector pos, vector size, __inout vector scrollofs, float num_servers) Menu_ServerList =
+{
+	vector rowsize = [size.x, 16];
+	vector listitem_pos = [0, 0, 0];
+	sui_fill(pos, size, [0, 0, 0], 0.75, 0);
+	sui_list_view_begin(strcat(id, "scrl"), pos, size, rowsize, num_servers, scrollofs, [0, 8]);
+	for (float index = sui_list_item(listitem_pos); index > -1; index = sui_list_item(listitem_pos))
+	{
+		sui_push_frame(listitem_pos, rowsize);
+		sui_set_align([SUI_ALIGN_START, SUI_ALIGN_CENTER]);
+
+		// bg
+		vector bpos = [0, 0];
+		vector bsize = [rowsize.x / 3, rowsize.y];
+		sui_fill(bpos, rowsize, [0.25, 0.25, 0.25], 0.5, 0);
+
+		// name
+		sui_fill(bpos, bsize, [0.25, 0.25, 0.25], 0.5, 0);
+		sui_text(bpos + [8, 0], MENU_TEXT_SMALL, gethostcachestring(gethostcacheindexforkey("name"), index), MENU_TEXT_1, 1, 0);
+
+		// map
+		bpos.x = size.x / 3;
+		sui_text(bpos + [8, 0], MENU_TEXT_SMALL, gethostcachestring(gethostcacheindexforkey("map"), index), MENU_TEXT_1, 1, 0);
+
+		// players
+		bpos.x *= 2;
+		string s = sprintf("%d/%d",
+			stof(gethostcachestring(gethostcacheindexforkey("numhumans"), index)),
+			stof(gethostcachestring(gethostcacheindexforkey("maxplayers"), index))
+		);
+		sui_fill(bpos, bsize, [0.25, 0.25, 0.25], 0.5, 0);
+		sui_text(bpos + [8, 0], MENU_TEXT_SMALL, s, MENU_TEXT_1, 1, 0);
+
+		sui_pop_frame();
+	}
+	sui_list_view_end();
+};
+
 struct name_command {
 	string name;
 	string command;
@@ -665,6 +762,13 @@ void(vector size) root_menu =
 		case MENU_MAIN: Menu_Main(); break;
 		case MENU_SOLO: menu_map_mode = MAP_SOLOSTOCK; Menu_Maps(); break;
 		case MENU_SOLOUSER: menu_map_mode = MAP_SOLOUSER; Menu_Maps(); break;
+		case MENU_COOP: Menu_Coop(); break;
+		case MENU_COOPJOIN: Menu_Coop_Join(); break;
+		case MENU_COOPBROWSE: Menu_Coop_Browse(); break;
+		case MENU_COOPDIRECT: Menu_Coop_Direct(); break;
+		case MENU_COOPCREATE: Menu_Coop_Create(); break;
+		case MENU_COOPSTOCK: menu_map_mode = MAP_COOPSTOCK; Menu_Maps(); break;
+		case MENU_COOPUSER: menu_map_mode = MAP_COOPUSER; Menu_Maps(); break;
 		case MENU_CREDITS: Menu_Credits(); break;
 
 #else

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -554,12 +554,9 @@ void(float order, vector minmaxsteps, string cvar_s, float is_int, float no_text
 
 static void(string id, vector pos, vector size, __inout string text, __inout float cursor) handle_text_input =
 {
-	float maxlen = 0;
-
-	if (getTextWidth(text, MENU_TEXT_SMALL.x) + 18 >= size.x)
-		maxlen = strlen(text);
-	else
-		maxlen = 128;
+	// best length to fit the largest character in the font
+	// ex: AAAAAAAAAAAAAAAAAAAAAAA
+	float maxlen = 23;
 
 	sui_action_element(pos, size, id, sui_noop);
 	if (sui_is_clicked(id)) cursor = strlen(text);

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -567,7 +567,8 @@ static void(string id, vector pos, vector size, __inout string text, __inout flo
 static void(vector pos, vector size, string text) draw_text_input =
 {
 	sui_push_frame(pos, size);
-	sui_fill([0, 0], size, [0.5, 0.1, 0.1], 1.0, 0);
+	sui_fill([0, 0], size, [0, 0, 0], 1.0, 0);
+	sui_border_box([0, 0], size, 2, [0.2, 0.2, 0.2], 0.3, 0);
 	sui_set_align([SUI_ALIGN_START, SUI_ALIGN_CENTER]);
 	sui_text([6, 0], MENU_TEXT_SMALL, text, MENU_TEXT_1, 1, 0);
 	sui_pop_frame();
@@ -580,7 +581,7 @@ static void(vector pos, vector size, string text) draw_text_input =
 void(string id, float order, __inout string text, __inout float cursor) Menu_TextInput =
 {
 	vector pos = [320, 50 + (order * 25)];
-	vector size = [240, 16];
+	vector size = [240, 20];
 
 	handle_text_input(id, pos, size, text, cursor);
 
@@ -594,7 +595,7 @@ void(string id, float order, __inout string text, __inout float cursor) Menu_Tex
 void(string id, float order, __inout string text, __inout float cursor) Menu_PasswordInput =
 {
 	vector pos = [320, 50 + (order * 25)];
-	vector size = [240, 16];
+	vector size = [240, 20];
 	string safe = "";
 
 	for (int i = 0; i < strlen(text); i++)

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -647,6 +647,18 @@ void(string id, vector pos, vector size, __inout vector scrollofs, float num_ser
 	sui_list_view_end();
 };
 
+void() Menu_StartCoop =
+{
+	localcmd("sv_public 2\n");
+	current_menu = MENU_COOPSTOCK;
+};
+
+void() Menu_StartSolo =
+{
+	localcmd("sv_public 0\n");
+	current_menu = MENU_SOLO;
+};
+
 struct name_command {
 	string name;
 	string command;

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -633,10 +633,21 @@ void(string id, vector pos, vector size, __inout vector scrollofs, float num_ser
 		sui_push_frame(listitem_pos, rowsize);
 		sui_set_align([SUI_ALIGN_START, SUI_ALIGN_CENTER]);
 
+		string listitem_id = strcat(id, "scrl", ftos(index));
+		sui_action_element([0, 0], rowsize, listitem_id, sui_noop);
+
 		// bg
 		vector bpos = [0, 0];
 		vector bsize = [(rowsize.x / 8) * 5, rowsize.y];
 		sui_fill(bpos, rowsize, [0.25, 0.25, 0.25], 0.5, 0);
+
+		// hovered bg
+		if (sui_is_hovered(listitem_id))
+			sui_fill(bpos, rowsize, [0.25, 0.25, 0.25], 0.5, 0);
+
+		// do it
+		if (sui_is_clicked(listitem_id))
+			localcmd("connect ", gethostcachestring(gethostcacheindexforkey("cname"), index), "\n");
 
 		// name
 		sui_fill(bpos, bsize, [0.25, 0.25, 0.25], 0.5, 0);

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -614,7 +614,7 @@ void(string id, vector pos, vector size, __inout vector scrollofs, float num_ser
 	vector rowsize = [size.x, 16];
 	vector listitem_pos = [0, 0, 0];
 	sui_fill(pos, size, [0, 0, 0], 0.75, 0);
-	sui_list_view_begin(strcat(id, "scrl"), pos, size, rowsize, num_servers, scrollofs, [0, 8]);
+	sui_list_view_begin(strcat(id, "scrl"), pos, size, rowsize, num_servers, scrollofs, [0, 16]);
 	for (float index = sui_list_item(listitem_pos); index > -1; index = sui_list_item(listitem_pos))
 	{
 		sui_push_frame(listitem_pos, rowsize);

--- a/source/menu/m_menu.qc
+++ b/source/menu/m_menu.qc
@@ -566,7 +566,7 @@ static void(string id, vector pos, vector size, __inout string text, __inout flo
 
 static void(vector pos, vector size, string text) draw_text_input =
 {
-	sui_push_frame(pos, size);
+	sui_push_frame(pos - [6, 5], size);
 	sui_fill([0, 0], size, [0, 0, 0], 1.0, 0);
 	sui_border_box([0, 0], size, 2, [0.2, 0.2, 0.2], 0.3, 0);
 	sui_set_align([SUI_ALIGN_START, SUI_ALIGN_CENTER]);
@@ -581,7 +581,7 @@ static void(vector pos, vector size, string text) draw_text_input =
 void(string id, float order, __inout string text, __inout float cursor) Menu_TextInput =
 {
 	vector pos = [320, 50 + (order * 25)];
-	vector size = [240, 20];
+	vector size = [290, 22];
 
 	handle_text_input(id, pos, size, text, cursor);
 
@@ -595,7 +595,7 @@ void(string id, float order, __inout string text, __inout float cursor) Menu_Tex
 void(string id, float order, __inout string text, __inout float cursor) Menu_PasswordInput =
 {
 	vector pos = [320, 50 + (order * 25)];
-	vector size = [240, 20];
+	vector size = [290, 22];
 	string safe = "";
 
 	for (int i = 0; i < strlen(text); i++)

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -1,0 +1,199 @@
+
+float player_name_cursor;
+string player_name;
+
+float server_ip_cursor;
+string server_ip;
+
+float server_hostname_cursor;
+string server_hostname;
+
+float server_password_cursor;
+string server_password;
+
+float server_port_cursor;
+string server_port;
+
+int num_cached_servers;
+
+void() Menu_Coop_Name_Update =
+{
+	static float initialized;
+	if (!initialized)
+	{
+		player_name = cvar_string("name");
+		player_name_cursor = strlen(player_name);
+		initialized = true;
+	}
+	else
+	{
+		cvar_set("name", player_name);
+	}
+};
+
+void() Menu_Coop_Hostname_Update =
+{
+	static float initialized;
+	if (!initialized)
+	{
+		server_hostname = cvar_string("hostname");
+		server_hostname_cursor = strlen(server_hostname);
+		initialized = true;
+	}
+	else
+	{
+		cvar_set("hostname", server_hostname);
+	}
+};
+
+void() Menu_Coop_Port_Update =
+{
+	static float initialized;
+	if (!initialized)
+	{
+		server_port = cvar_string("sv_port");
+		server_port_cursor = strlen(server_port);
+		initialized = true;
+	}
+	else
+	{
+		cvar_set("sv_port", server_port);
+	}
+};
+
+void() Menu_Coop_Password_Update =
+{
+	static float initialized;
+	if (!initialized)
+	{
+		server_password = cvar_string("password");
+		server_password_cursor = strlen(server_password);
+		initialized = true;
+	}
+	else
+	{
+		cvar_set("password", server_password);
+	}
+};
+
+void() Menu_Coop_Browse_Refresh =
+{
+	static float refreshtime;
+
+	if (refreshtime > time)
+		return;
+
+	refreshtime = time + 0.5;
+
+	resethostcachemasks();
+	// TODO: figure out why this returns 0 servers
+	// sethostcachemaskstring(0, gethostcacheindexforkey("gamedir"), cvar_string("game"), SLIST_TEST_EQUAL);
+	sethostcachesort(gethostcacheindexforkey("ping"), false);
+	refreshhostcache(false);
+	resorthostcache();
+
+	num_cached_servers = (int)gethostcachevalue(SLIST_HOSTCACHEVIEWCOUNT);
+};
+
+void() Menu_Coop_Browse =
+{
+
+	Menu_Coop_Browse_Refresh();
+
+	Menu_DrawBackground();
+
+	Menu_DrawTitle("BROWSE SERVERS");
+
+	// draw server list
+	sui_set_align([SUI_ALIGN_CENTER, SUI_ALIGN_CENTER]);
+	static vector serverlist_scrollofs;
+	vector vsize = sui_current_frame_size();
+	Menu_ServerList("cbm_serverlist", [0, 0], [vsize.x, vsize.y / 2], serverlist_scrollofs, num_cached_servers);
+
+	Menu_Button(-1, "cbm_back", "BACK", "Return to Join Game Menu.") ? current_menu = MENU_COOPJOIN : 0;
+
+	sui_pop_frame();
+};
+
+void() Menu_Coop_Direct =
+{
+	Menu_Coop_Password_Update();
+
+	Menu_DrawBackground();
+
+	Menu_DrawTitle("DIRECT IP/ID");
+
+	Menu_Button(1, "cdm_serverip", "SERVER IP/ROOM ID", "IP or ID for the Server (typically starts with /).");
+	Menu_TextInput("cdm_serverip", 1, server_ip, server_ip_cursor);
+
+	Menu_Button(2, "cdm_serverpassword", "SERVER PASSWORD", "Password for the Match set by the Host.");
+	Menu_PasswordInput("cdm_serverpassword", 2, server_password, server_password_cursor);
+
+	Menu_DrawDivider(3);
+	Menu_Button(3.25, "cdm_connect", "CONNECT TO SERVER", "Attempt to connect to Game.") ? localcmd("connect ", server_ip, "\n") : 0;
+
+	Menu_Button(-1, "cdm_back", "BACK", "Return to Join Game Menu.") ? current_menu = MENU_COOPJOIN : 0;
+
+	sui_pop_frame();
+};
+
+void() Menu_Coop_Join =
+{
+	Menu_DrawBackground();
+
+	Menu_DrawTitle("JOIN GAME");
+
+	Menu_Button(1, "cjm_browse", "BROWSE SERVERS", "Browse the list of active Servers.") ? current_menu = MENU_COOPBROWSE : 0;
+	Menu_Button(2, "cjm_direct", "DIRECT IP/ID", "Connect directly to an active Server.") ? current_menu = MENU_COOPDIRECT : 0;
+
+	Menu_Button(-1, "cjm_back", "BACK", "Return to Co-Op Menu.") ? current_menu = MENU_COOP : 0;
+
+	sui_pop_frame();
+};
+
+void() Menu_Coop_Create =
+{
+	Menu_Coop_Hostname_Update();
+	Menu_Coop_Port_Update();
+	Menu_Coop_Password_Update();
+
+	Menu_DrawBackground();
+
+	Menu_DrawTitle("CREATE GAME");
+
+	Menu_Button(1, "ccm_servername", "SERVER NAME", "Enter a name that will appear in the Server List.");
+	Menu_TextInput("ccm_servername", 1, server_hostname, server_hostname_cursor);
+
+	Menu_Button(2, "ccm_port", "SERVER PORT", "Edit the port that the Server will use.");
+	Menu_TextInput("ccm_port", 2, server_port, server_port_cursor);
+
+	Menu_Button(3, "ccm_password", "SERVER PASSWORD", "Enter an (optional) password to limit who can join.");
+	Menu_PasswordInput("ccm_password", 3, server_password, server_password_cursor);
+
+	Menu_DrawDivider(4);
+	Menu_Button(4.25, "ccm_choosemap", "CHOOSE MAP", "Select a Map to start the Game.") ? current_menu = MENU_COOPSTOCK : 0;
+
+	Menu_Button(-1, "ccm_back", "BACK", "Return to Co-Op Menu.") ? current_menu = MENU_COOP : 0;
+
+	sui_pop_frame();
+};
+
+void() Menu_Coop =
+{
+	Menu_Coop_Name_Update();
+
+	Menu_DrawBackground();
+
+	Menu_DrawTitle("COOPERATIVE");
+
+	Menu_Button(1, "cm_playername", "PLAYER NAME", "Name that appears in-game and on the Scoreboard.");
+	Menu_TextInput("cm_playername", 1, player_name, player_name_cursor);
+
+	Menu_DrawDivider(2);
+	Menu_Button(2.25, "cm_join", "JOIN GAME", "Join an in-progress Match.") ? current_menu = MENU_COOPJOIN : 0;
+	Menu_Button(3.25, "cm_create", "CREATE GAME", "Create a new Match for others to join.") ? current_menu = MENU_COOPCREATE : 0;
+
+	Menu_Button(-1, "cm_back", "BACK", "Return to Main Menu.") ? current_menu = MENU_MAIN : 0;
+
+	sui_pop_frame();
+};

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -126,7 +126,7 @@ void() Menu_Coop_Direct =
 	Menu_Button(1, "cdm_serverip", "SERVER IP/ROOM ID", "IP or ID for the Server (typically starts with /).");
 	Menu_TextInput("cdm_serverip", 1, server_ip, server_ip_cursor);
 
-	Menu_Button(2, "cdm_serverpassword", "SERVER PASSWORD", "Password for the Match set by the Host.");
+	Menu_Button(2, "cdm_serverpassword", "SERVER PASSWORD", "Password for the Match set by the Host (optional).");
 	Menu_PasswordInput("cdm_serverpassword", 2, server_password, server_password_cursor);
 
 	Menu_DrawDivider(3);

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -86,12 +86,22 @@ void() Menu_Coop_Browse_Refresh =
 
 	refreshtime = time + 0.5;
 
+	// reset cache masks
 	resethostcachemasks();
+
+	// set the masks to our gamedir and game strings
 	sethostcachemaskstring(0, gethostcacheindexforkey("gamedir"), cvar_string("game"), SLIST_TEST_EQUAL);
+
+	// set sort value to ping (ascending)
 	sethostcachesort(gethostcacheindexforkey("ping"), false);
+
+	// flush the current cache and refresh it
 	refreshhostcache(true);
+
+	// resort the cache (by ping)
 	resorthostcache();
 
+	// get number of cached servers
 	num_cached_servers = (int)gethostcachevalue(SLIST_HOSTCACHEVIEWCOUNT);
 };
 
@@ -112,6 +122,7 @@ void() Menu_Coop_Browse_Update =
 
 	refreshtime = time + 0.5;
 
+	// call this every 0.5 seconds to keep probing the cache, but without flushing everything
 	num_cached_servers = (int)gethostcachevalue(SLIST_HOSTCACHEVIEWCOUNT);
 };
 

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -139,10 +139,16 @@ void() Menu_Coop_Browse =
 	static vector serverlist_scrollofs;
 	vector vsize = sui_current_frame_size();
 	Menu_ServerList("cbm_serverlist", [0, 0], [vsize.x, vsize.y / 2], serverlist_scrollofs, num_cached_servers);
-	sui_text([0, (vsize.y / -3) + 16], MENU_TEXT_SMALL, "NOTE: Mouse input only.", [1, 1, 1], 1, 0);
 
 	Menu_Button(-2, "cbm_refresh", "REFRESH", "Refresh server list.") ? Menu_Coop_RefreshCache() : 0;
 	Menu_Button(-1, "cbm_back", "BACK", "Return to Join Game Menu.") ? current_menu = MENU_COOPJOIN : 0;
+
+	// draw tooltip
+	if (!sui_is_hovered("cbm_refresh") && !sui_is_hovered("cbm_back"))
+	{
+		sui_set_align([SUI_ALIGN_CENTER, SUI_ALIGN_END]);
+		sui_text([0, -30], MENU_TEXT_MEDIUM, "NOTE: Keyboard or gamepad is not supported for server selection.", [1, 1, 1], 1, 0);
+	}
 
 	sui_pop_frame();
 };

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -76,6 +76,7 @@ void() Menu_Coop_Password_Update =
 	}
 };
 
+// this flushes the server cache
 void() Menu_Coop_Browse_Refresh =
 {
 	static float refreshtime;
@@ -83,7 +84,27 @@ void() Menu_Coop_Browse_Refresh =
 	if (refreshtime > time)
 		return;
 
-	refreshtime = time + 0.1;
+	refreshtime = time + 0.5;
+
+	resethostcachemasks();
+	// TODO: figure out why this returns 0 servers
+	// sethostcachemaskstring(0, gethostcacheindexforkey("gamedir"), cvar_string("game"), SLIST_TEST_EQUAL);
+	sethostcachesort(gethostcacheindexforkey("ping"), false);
+	refreshhostcache(true);
+	resorthostcache();
+
+	num_cached_servers = (int)gethostcachevalue(SLIST_HOSTCACHEVIEWCOUNT);
+};
+
+// this updates the current server cache
+void() Menu_Coop_Browse_Update =
+{
+	static float refreshtime;
+
+	if (refreshtime > time)
+		return;
+
+	refreshtime = time + 0.5;
 
 	resethostcachemasks();
 	// TODO: figure out why this returns 0 servers
@@ -97,12 +118,13 @@ void() Menu_Coop_Browse_Refresh =
 
 void() Menu_Coop_Browse =
 {
-
-	Menu_Coop_Browse_Refresh();
+	Menu_Coop_Browse_Update();
 
 	Menu_DrawBackground();
 
 	Menu_DrawTitle("BROWSE SERVERS");
+
+	// refresh button
 
 	// draw server list
 	sui_set_align([SUI_ALIGN_CENTER, SUI_ALIGN_CENTER]);
@@ -110,6 +132,7 @@ void() Menu_Coop_Browse =
 	vector vsize = sui_current_frame_size();
 	Menu_ServerList("cbm_serverlist", [0, 0], [vsize.x, vsize.y / 2], serverlist_scrollofs, num_cached_servers);
 
+	Menu_Button(-2, "cbm_refresh", "REFRESH", "Refresh server list.") ? Menu_Coop_Browse_Refresh() : 0;
 	Menu_Button(-1, "cbm_back", "BACK", "Return to Join Game Menu.") ? current_menu = MENU_COOPJOIN : 0;
 
 	sui_pop_frame();

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -87,8 +87,7 @@ void() Menu_Coop_Browse_Refresh =
 	refreshtime = time + 0.5;
 
 	resethostcachemasks();
-	// TODO: figure out why this returns 0 servers
-	// sethostcachemaskstring(0, gethostcacheindexforkey("gamedir"), cvar_string("game"), SLIST_TEST_EQUAL);
+	sethostcachemaskstring(0, gethostcacheindexforkey("gamedir"), cvar_string("game"), SLIST_TEST_EQUAL);
 	sethostcachesort(gethostcacheindexforkey("ping"), false);
 	refreshhostcache(true);
 	resorthostcache();
@@ -100,18 +99,18 @@ void() Menu_Coop_Browse_Refresh =
 void() Menu_Coop_Browse_Update =
 {
 	static float refreshtime;
+	static float initialized;
+
+	if (!initialized)
+	{
+		Menu_Coop_Browse_Refresh();
+		initialized = true;
+	}
 
 	if (refreshtime > time)
 		return;
 
 	refreshtime = time + 0.5;
-
-	resethostcachemasks();
-	// TODO: figure out why this returns 0 servers
-	// sethostcachemaskstring(0, gethostcacheindexforkey("gamedir"), cvar_string("game"), SLIST_TEST_EQUAL);
-	sethostcachesort(gethostcacheindexforkey("ping"), false);
-	refreshhostcache(false);
-	resorthostcache();
 
 	num_cached_servers = (int)gethostcachevalue(SLIST_HOSTCACHEVIEWCOUNT);
 };
@@ -123,8 +122,6 @@ void() Menu_Coop_Browse =
 	Menu_DrawBackground();
 
 	Menu_DrawTitle("BROWSE SERVERS");
-
-	// refresh button
 
 	// draw server list
 	sui_set_align([SUI_ALIGN_CENTER, SUI_ALIGN_CENTER]);

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -217,3 +217,83 @@ void() Menu_Coop =
 
 	sui_pop_frame();
 };
+
+string menu_coop_browse_buttons[] = {
+	"cbm_serverlist", "cbm_refresh", "cbm_back"
+};
+
+string menu_coop_direct_buttons[] = {
+	"cdm_serverip", "cdm_serverpassword", "cdm_connect", "cdm_back"
+};
+
+string menu_coop_join_buttons[] = {
+	"cjm_browse", "cjm_direct", "cjm_back"
+};
+
+string menu_coop_create_buttons[] = {
+	"ccm_servername", "ccm_port", "ccm_password", "ccm_choosemap", "ccm_back"
+};
+
+string menu_coop_buttons[] = {
+	"cm_playername", "cm_join", "cm_create", "cm_back"
+};
+
+// can you tell i'm a C user at heart? -- erysdren
+
+#define NEXTBUTTON_FUNC(fn, arr) 				\
+string(string prev_id) fn ## _GetNextButton =	\
+{ 												\
+	if (prev_id == "") 							\
+		return arr[0]; 							\
+												\
+	string ret = arr[0];						\
+												\
+	for(float i = 0; i < arr.length; i++) {		\
+		if (arr[i] == prev_id) {				\
+			if (i + 1 >= arr.length)			\
+				break;							\
+												\
+			ret = arr[i + 1];					\
+			break;								\
+		}										\
+	}											\
+												\
+	return ret;									\
+};												\
+
+NEXTBUTTON_FUNC(Menu_Coop_Browse, menu_coop_browse_buttons)
+NEXTBUTTON_FUNC(Menu_Coop_Direct, menu_coop_direct_buttons)
+NEXTBUTTON_FUNC(Menu_Coop_Join, menu_coop_join_buttons)
+NEXTBUTTON_FUNC(Menu_Coop_Create, menu_coop_create_buttons)
+NEXTBUTTON_FUNC(Menu_Coop, menu_coop_buttons)
+
+#undef NEXTBUTTON_FUNC
+
+#define PREVBUTTON_FUNC(fn, arr) 					\
+string(string next_id) fn ## _GetPreviousButton =	\
+{													\
+	if (next_id == "")								\
+		return arr[arr.length - 1];					\
+													\
+	string ret = arr[arr.length - 1];				\
+													\
+	for(float i = arr.length - 1; i > 0; i--) {		\
+		if (arr[i] == next_id) {					\
+			if (i - 1 < 0)							\
+				break;								\
+													\
+			ret = arr[i - 1];						\
+			break;									\
+		}											\
+	}												\
+													\
+	return ret;										\
+};													\
+
+PREVBUTTON_FUNC(Menu_Coop_Browse, menu_coop_browse_buttons)
+PREVBUTTON_FUNC(Menu_Coop_Direct, menu_coop_direct_buttons)
+PREVBUTTON_FUNC(Menu_Coop_Join, menu_coop_join_buttons)
+PREVBUTTON_FUNC(Menu_Coop_Create, menu_coop_create_buttons)
+PREVBUTTON_FUNC(Menu_Coop, menu_coop_buttons)
+
+#undef PREVBUTTON_FUNC

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -16,7 +16,7 @@ string server_port;
 
 int num_cached_servers;
 
-void() Menu_Coop_Name_Update =
+void() Menu_Coop_UpdateName =
 {
 	static float initialized;
 	if (!initialized)
@@ -31,7 +31,7 @@ void() Menu_Coop_Name_Update =
 	}
 };
 
-void() Menu_Coop_Hostname_Update =
+void() Menu_Coop_UpdateHostname =
 {
 	static float initialized;
 	if (!initialized)
@@ -46,7 +46,7 @@ void() Menu_Coop_Hostname_Update =
 	}
 };
 
-void() Menu_Coop_Port_Update =
+void() Menu_Coop_UpdatePort =
 {
 	static float initialized;
 	if (!initialized)
@@ -61,7 +61,7 @@ void() Menu_Coop_Port_Update =
 	}
 };
 
-void() Menu_Coop_Password_Update =
+void() Menu_Coop_UpdatePassword =
 {
 	static float initialized;
 	if (!initialized)
@@ -77,7 +77,7 @@ void() Menu_Coop_Password_Update =
 };
 
 // this flushes the server cache
-void() Menu_Coop_Browse_Refresh =
+void() Menu_Coop_RefreshCache =
 {
 	static float refreshtime;
 
@@ -106,14 +106,14 @@ void() Menu_Coop_Browse_Refresh =
 };
 
 // this updates the current server cache
-void() Menu_Coop_Browse_Update =
+void() Menu_Coop_UpdateCache =
 {
 	static float refreshtime;
 	static float initialized;
 
 	if (!initialized)
 	{
-		Menu_Coop_Browse_Refresh();
+		Menu_Coop_RefreshCache();
 		initialized = true;
 	}
 
@@ -128,7 +128,7 @@ void() Menu_Coop_Browse_Update =
 
 void() Menu_Coop_Browse =
 {
-	Menu_Coop_Browse_Update();
+	Menu_Coop_UpdateCache();
 
 	Menu_DrawBackground();
 
@@ -140,7 +140,7 @@ void() Menu_Coop_Browse =
 	vector vsize = sui_current_frame_size();
 	Menu_ServerList("cbm_serverlist", [0, 0], [vsize.x, vsize.y / 2], serverlist_scrollofs, num_cached_servers);
 
-	Menu_Button(-2, "cbm_refresh", "REFRESH", "Refresh server list.") ? Menu_Coop_Browse_Refresh() : 0;
+	Menu_Button(-2, "cbm_refresh", "REFRESH", "Refresh server list.") ? Menu_Coop_RefreshCache() : 0;
 	Menu_Button(-1, "cbm_back", "BACK", "Return to Join Game Menu.") ? current_menu = MENU_COOPJOIN : 0;
 
 	sui_pop_frame();
@@ -148,7 +148,7 @@ void() Menu_Coop_Browse =
 
 void() Menu_Coop_Direct =
 {
-	Menu_Coop_Password_Update();
+	Menu_Coop_UpdatePassword();
 
 	Menu_DrawBackground();
 
@@ -184,9 +184,9 @@ void() Menu_Coop_Join =
 
 void() Menu_Coop_Create =
 {
-	Menu_Coop_Hostname_Update();
-	Menu_Coop_Port_Update();
-	Menu_Coop_Password_Update();
+	Menu_Coop_UpdateHostname();
+	Menu_Coop_UpdatePort();
+	Menu_Coop_UpdatePassword();
 
 	Menu_DrawBackground();
 
@@ -211,7 +211,7 @@ void() Menu_Coop_Create =
 
 void() Menu_Coop =
 {
-	Menu_Coop_Name_Update();
+	Menu_Coop_UpdateName();
 
 	Menu_DrawBackground();
 

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -139,6 +139,7 @@ void() Menu_Coop_Browse =
 	static vector serverlist_scrollofs;
 	vector vsize = sui_current_frame_size();
 	Menu_ServerList("cbm_serverlist", [0, 0], [vsize.x, vsize.y / 2], serverlist_scrollofs, num_cached_servers);
+	sui_text([0, (vsize.y / -3) + 16], MENU_TEXT_SMALL, "NOTE: Mouse input only.", [1, 1, 1], 1, 0);
 
 	Menu_Button(-2, "cbm_refresh", "REFRESH", "Refresh server list.") ? Menu_Coop_RefreshCache() : 0;
 	Menu_Button(-1, "cbm_back", "BACK", "Return to Join Game Menu.") ? current_menu = MENU_COOPJOIN : 0;

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -83,7 +83,7 @@ void() Menu_Coop_Browse_Refresh =
 	if (refreshtime > time)
 		return;
 
-	refreshtime = time + 0.5;
+	refreshtime = time + 0.1;
 
 	resethostcachemasks();
 	// TODO: figure out why this returns 0 servers

--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -171,7 +171,7 @@ void() Menu_Coop_Create =
 	Menu_PasswordInput("ccm_password", 3, server_password, server_password_cursor);
 
 	Menu_DrawDivider(4);
-	Menu_Button(4.25, "ccm_choosemap", "CHOOSE MAP", "Select a Map to start the Game.") ? current_menu = MENU_COOPSTOCK : 0;
+	Menu_Button(4.25, "ccm_choosemap", "CHOOSE MAP", "Select a Map to start the Game.") ? Menu_StartCoop() : 0;
 
 	Menu_Button(-1, "ccm_back", "BACK", "Return to Co-Op Menu.") ? current_menu = MENU_COOP : 0;
 

--- a/source/menu/menu_main.qc
+++ b/source/menu/menu_main.qc
@@ -71,7 +71,7 @@ void() Menu_Main =
     Menu_DrawTitle("MAIN MENU");
     Menu_DrawBuildDate();
 
-    Menu_Button(1, "mm_start", "SOLO", "Play Solo.") ? current_menu = MENU_SOLO : 0;
+    Menu_Button(1, "mm_start", "SOLO", "Play Solo.") ? Menu_StartSolo() : 0;
     Menu_Button(2, "mm_coop", "COOPERATIVE", "Play with up to Four Players.") ? current_menu = MENU_COOP : 0;
     Menu_DrawDivider(3);
     Menu_Button(3.25, "mm_options", "CONFIGURATION", "Tweak Game related Options.") ? current_menu = MENU_OPTIONS : 0;

--- a/source/menu/menu_main.qc
+++ b/source/menu/menu_main.qc
@@ -72,7 +72,7 @@ void() Menu_Main =
     Menu_DrawBuildDate();
 
     Menu_Button(1, "mm_start", "SOLO", "Play Solo.") ? current_menu = MENU_SOLO : 0;
-    Menu_Button(2, "mm_coop", "COOPERATIVE", "Play with up to Four Players.") ? localcmd("\n") : 0;
+    Menu_Button(2, "mm_coop", "COOPERATIVE", "Play with up to Four Players.") ? current_menu = MENU_COOP : 0;
     Menu_DrawDivider(3);
     Menu_Button(3.25, "mm_options", "CONFIGURATION", "Tweak Game related Options.") ? current_menu = MENU_OPTIONS : 0;
     //Menu_Button(4.25, "mm_achievements", "ACHIEVEMENTS", "View Achievement Progress.") ? localcmd("\n") : 0;

--- a/source/menu/menu_maps.qc
+++ b/source/menu/menu_maps.qc
@@ -105,8 +105,8 @@ void() Menu_Maps =
     switch(menu_map_mode) {
         case MAP_SOLOSTOCK: Menu_DrawTitle("SELECT MAP: SOLO"); back_string = "Return to Main Menu."; back_menudest = MENU_MAIN; break;
         case MAP_SOLOUSER: Menu_DrawTitle("USER MAPS: SOLO"); back_string = "Return to Stock Map selection."; back_menudest = MENU_SOLO; break;
-        case MAP_COOPSTOCK: Menu_DrawTitle("SELECT MAP: COOP"); break;
-        case MAP_COOPUSER: Menu_DrawTitle("USER MAPS: COOP"); break;
+        case MAP_COOPSTOCK: Menu_DrawTitle("SELECT MAP: COOP"); back_string = "Return to Create Game Menu."; back_menudest = MENU_COOPCREATE; break;
+        case MAP_COOPUSER: Menu_DrawTitle("USER MAPS: COOP"); back_string = "Return to Stock Map selection."; back_menudest = MENU_COOPSTOCK; break;
         default: break;
     }
 
@@ -128,7 +128,12 @@ void() Menu_Maps =
             Menu_MapButton(i + 1, sprintf("map_%s", stock_maps[i].bsp_name), stock_maps[i].bsp_name, -1) ? Menu_Maps_LoadMap(stock_maps[i].bsp_name) : 0;
         }
         Menu_DrawDivider(i + 1.25);
-        Menu_Button(i + 1.5, "map_nzpusermaps", "USER MAPS", "View User-Created Maps.") ? current_menu = MENU_SOLOUSER : 0;
+
+		if (menu_map_mode == MAP_SOLOSTOCK) {
+			Menu_Button(i + 1.5, "map_nzpusermaps", "USER MAPS", "View User-Created Maps.") ? current_menu = MENU_SOLOUSER : 0;
+		} else if (menu_map_mode == MAP_COOPSTOCK) {
+			Menu_Button(i + 1.5, "map_nzpusermaps", "USER MAPS", "View User-Created Maps.") ? current_menu = MENU_COOPUSER : 0;
+		}
 
         // Usermaps and back button registry
         menu_maps_buttons[i] = "map_nzpusermaps";

--- a/source/menu/sui_sys.qc
+++ b/source/menu/sui_sys.qc
@@ -400,17 +400,23 @@ void() _sui_menukey_downarrow =
 		case MENU_MAIN:
 			_hover_actions[0] = Menu_Main_GetNextButton(current_hovered_option);
 			break;
-		// TODO: do this
-#if 0
 		case MENU_COOP:
-		case MENU_COOPJOIN:
-		case MENU_COOPBROWSE:
-		case MENU_COOPDIRECT:
-		case MENU_COOPCREATE:
-		case MENU_COOPSTOCK:
-			_hover_actions[0] = Menu_Maps_GetNextButton(current_hovered_option);
+			_hover_actions[0] = Menu_Coop_GetNextButton(current_hovered_option);
 			break;
-#endif
+		case MENU_COOPJOIN:
+			_hover_actions[0] = Menu_Coop_Join_GetNextButton(current_hovered_option);
+			break;
+		case MENU_COOPBROWSE:
+			_hover_actions[0] = Menu_Coop_Browse_GetNextButton(current_hovered_option);
+			break;
+		case MENU_COOPDIRECT:
+			_hover_actions[0] = Menu_Coop_Direct_GetNextButton(current_hovered_option);
+			break;
+		case MENU_COOPCREATE:
+			_hover_actions[0] = Menu_Coop_Create_GetNextButton(current_hovered_option);
+			break;
+		case MENU_COOPSTOCK:
+		case MENU_COOPUSER:
 		case MENU_SOLO:
 		case MENU_SOLOUSER:
 			_hover_actions[0] = Menu_Maps_GetNextButton(current_hovered_option);
@@ -460,6 +466,23 @@ void() _sui_menukey_uparrow =
 		case MENU_MAIN:
 			_hover_actions[0] = Menu_Main_GetPreviousButton(current_hovered_option);
 			break;
+		case MENU_COOP:
+			_hover_actions[0] = Menu_Coop_GetPreviousButton(current_hovered_option);
+			break;
+		case MENU_COOPJOIN:
+			_hover_actions[0] = Menu_Coop_Join_GetPreviousButton(current_hovered_option);
+			break;
+		case MENU_COOPBROWSE:
+			_hover_actions[0] = Menu_Coop_Browse_GetPreviousButton(current_hovered_option);
+			break;
+		case MENU_COOPDIRECT:
+			_hover_actions[0] = Menu_Coop_Direct_GetPreviousButton(current_hovered_option);
+			break;
+		case MENU_COOPCREATE:
+			_hover_actions[0] = Menu_Coop_Create_GetPreviousButton(current_hovered_option);
+			break;
+		case MENU_COOPSTOCK:
+		case MENU_COOPUSER:
 		case MENU_SOLO:
 		case MENU_SOLOUSER:
 			_hover_actions[0] = Menu_Maps_GetPreviousButton(current_hovered_option);

--- a/source/menu/sui_sys.qc
+++ b/source/menu/sui_sys.qc
@@ -671,10 +671,8 @@ string() sui_listen_text_input =
 	return "";
 };
 
-void(float char, float scan, __inout string text, __inout float cursor) sui_handle_text_input =
+void(float char, float scan, float maxlen, __inout string text, __inout float cursor) sui_handle_text_input =
 {
-	float maxlen = 128;
-	
 	string prev = text;
 	string pre_cursor, post_cursor;
 	float length = strlen(prev);
@@ -941,7 +939,7 @@ float(string id, vector pos, vector size, vector minmaxsteps, float value, void(
 	return newvalue;
 };
 
-void(string id, vector pos, vector size, __inout string text, __inout float cursor) sui_text_input =
+void(string id, vector pos, vector size, float maxlen, __inout string text, __inout float cursor) sui_text_input =
 {
 	sui_action_element(pos, size, id, sui_noop);
 	if (sui_is_clicked(id)) cursor = strlen(text);
@@ -949,7 +947,7 @@ void(string id, vector pos, vector size, __inout string text, __inout float curs
 	{
 		float char = 0;
 		float scan = 0;
-		while(sui_get_input(char, scan)) sui_handle_text_input(char, scan, text, cursor);
+		while(sui_get_input(char, scan)) sui_handle_text_input(char, scan, maxlen, text, cursor);
 	}
 };
 

--- a/source/menu/sui_sys.qc
+++ b/source/menu/sui_sys.qc
@@ -400,6 +400,17 @@ void() _sui_menukey_downarrow =
 		case MENU_MAIN:
 			_hover_actions[0] = Menu_Main_GetNextButton(current_hovered_option);
 			break;
+		// TODO: do this
+#if 0
+		case MENU_COOP:
+		case MENU_COOPJOIN:
+		case MENU_COOPBROWSE:
+		case MENU_COOPDIRECT:
+		case MENU_COOPCREATE:
+		case MENU_COOPSTOCK:
+			_hover_actions[0] = Menu_Maps_GetNextButton(current_hovered_option);
+			break;
+#endif
 		case MENU_SOLO:
 		case MENU_SOLOUSER:
 			_hover_actions[0] = Menu_Maps_GetNextButton(current_hovered_option);

--- a/source/menu/sui_sys.qc
+++ b/source/menu/sui_sys.qc
@@ -676,7 +676,7 @@ void(float char, float scan, __inout string text, __inout float cursor) sui_hand
 		text = sprintf("%s%s%s", pre_cursor, chr2str(char), post_cursor);
 		cursor += 1;
 	}
-	else if (char == 8) // backspace
+	else if (char == 8 || scan == K_BACKSPACE) // backspace
 	{
 		if (cursor <= 0) return;
 		pre_cursor = substring(prev, 0, cursor - 1);
@@ -692,7 +692,7 @@ void(float char, float scan, __inout string text, __inout float cursor) sui_hand
 		post_cursor = substring(prev, cursor + 1, length);
 		text = strcat(pre_cursor, post_cursor);
 	}
-	else if (char == 13 || char == 27) // enter or escape
+	else if (char == 13 || char == 27 || scan == K_ENTER || scan == K_ESCAPE) // enter or escape
 	{
 		// Commit and deselect...
 		// Let's try a hack..


### PR DESCRIPTION
Added:
- Co-Op menu tree, including the menus for changing the player's name, joining a game directly, browsing servers, and creating servers.

Bugs:
- SUI's builtin text input is a bit unfinished, I need to code in a way to cap the length to the size of the drawn box.

Unfinished:
- The server list needs better styling and also needs interactivity added, as well as sorting (maybe).
- I need to add the equivalent `Menu_*_GetNextButton` and `Menu_*_GetPreviousButton` functions for the Co-Op menus. I will probably do those last, though it will need special care to account for the server list.
- The "Create Game" menu doesn't properly create the server at the end of the options. The "Maps" menu might need to be edited slightly to account for this.
