### PR TITLE
MENU: menu_coop.qc: fix macro syntax error

### DIFF
--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -308,7 +308,7 @@ string(string prev_id) fn ## _GetNextButton =	\
 	}											\
 												\
 	return ret;									\
-};												\
+};
 
 NEXTBUTTON_FUNC(Menu_Coop_Browse, menu_coop_browse_buttons)
 NEXTBUTTON_FUNC(Menu_Coop_Direct, menu_coop_direct_buttons)
@@ -337,7 +337,7 @@ string(string next_id) fn ## _GetPreviousButton =	\
 	}												\
 													\
 	return ret;										\
-};													\
+};
 
 PREVBUTTON_FUNC(Menu_Coop_Browse, menu_coop_browse_buttons)
 PREVBUTTON_FUNC(Menu_Coop_Direct, menu_coop_direct_buttons)


### PR DESCRIPTION
this doesn't affect our current in-repo build of FTEQCC, but newer builds of FTEQCC have been affected. this addresses https://github.com/nzp-team/quakec/issues/93