### PR TITLE
Add client support for up to 8 players

### DIFF
--- a/source/client/defs/custom.qc
+++ b/source/client/defs/custom.qc
@@ -71,7 +71,7 @@ var struct revive_s {
 	float draw;
 	float timer;
 	float state;
-} revive_icons[4]; // MAX_CLIENTS
+} revive_icons[8]; // MAX_CLIENTS
 
 float weaponframetime;
 float weapon2frametime;

--- a/source/client/hud.qc
+++ b/source/client/hud.qc
@@ -343,7 +343,7 @@ void() HUD_Points =
 	float backwidth = 0.8*g_width;
 	vector TEXTCOLOR = '0 0 0';
 
-	for (int i = 3; i >= 0; i = i - 1)
+	for (int i = 7; i >= 0; i = i - 1)
 	{
 		float player_number = getplayerkeyfloat(i, "client_index");
 		entity client = findfloat(world, playernum, player_number);
@@ -1994,7 +1994,7 @@ void() HUD_Spectator =
 
 void() HUD_PlayerNames =
 {
-	for (float i = 3; i >= 0; i = i - 1) {
+	for (float i = 7; i >= 0; i = i - 1) {
 		float player_number = getplayerkeyfloat(i, "client_index");
 
 		if (player_number == getstatf(STAT_PLAYERNUM))
@@ -2038,7 +2038,7 @@ void() HUD_PlayerNames =
 
 void() HUD_ReviveIcons =
 {
-	for (float i = 3; i >= 0; i = i - 1) {
+	for (float i = 7; i >= 0; i = i - 1) {
 		float player_index = i;
 
 		// Don't render our own Icon.

--- a/source/client/hud.qc
+++ b/source/client/hud.qc
@@ -1654,7 +1654,7 @@ void() HUD_Scores =
 		Draw_String([g_width/2 + (header_x_pos - getTextWidth("Headshots", scoreboard_text_size)/2), 180], "Headshots", [scoreboard_text_size, scoreboard_text_size], TEXTCOLOR, 1, 0); 
 		header_x_pos += header_x_increment;
 	
-		for (int i = 0; i < 4; i = i + 1)
+		for (int i = 0; i < 8; i = i + 1)
 		{
 			float player_number = getplayerkeyfloat(i, "client_index");
 			entity client = findfloat(world, playernum, player_number);


### PR DESCRIPTION
Basically just allows more than 4 players to have nametags, show on the scoreboard and point counter bits. I've tested this and it looks like everything works regardless of how many players there are.

Was told on the Discord that as long as the fixes aren't hacky they would be merged, and I *think* they're probably not hacky so yea.