### PR TITLE
Fix incorrect mag size for Gewehr 43

### DIFF
--- a/source/shared/weapon_stats.qc
+++ b/source/shared/weapon_stats.qc
@@ -618,9 +618,9 @@ float(float wep) getWeaponMag =
 		case W_IMPELLER:
 			return 64;
 		case W_GEWEHR:
-			return 12;
-		case W_COMPRESSOR:
 			return 10;
+		case W_COMPRESSOR:
+			return 12;
 		case W_KAR_SCOPE:
 			return 5;
 		case W_HEADCRACKER:


### PR DESCRIPTION
The Gewehr 43's magazine size was swapped between its base and PaP variation - this fixes that.
Closes <https://github.com/nzp-team/nzportable/issues/1102>.