### PR TITLE
Move powerups blink logic to client

### DIFF
--- a/source/client/hud.qc
+++ b/source/client/hud.qc
@@ -1535,29 +1535,76 @@ void() HUD_Crosshair =
 	}
 }
 
+// Blink values for powerups, should be client-side.
+float 	instakill_blink;
+float 	x2_blink;
+
+//
+// HUD_PowerUpBlink(blink_delay, powerup_endtime)
+// Determines whether or not the Power-Up HUD icon should be
+// visible.
+// 
+float(__inout float blink_delay, float powerup_endtime) HUD_PowerUpBlink =
+{
+	// Powerup is already expired
+	if (powerup_endtime < servertime) { return false; }
+
+	// If there's less than five seconds remaining,
+	// blink every 0.2s.
+	if (powerup_endtime < servertime + 5) {
+		if (blink_delay < servertime - 0.2)
+			blink_delay = servertime + 0.2;
+	}
+	// If there's less than 10 seconds remaining,
+	// blink every 0.4s.
+	else if (powerup_endtime < servertime + 10) {
+		if (blink_delay < servertime - 0.4)
+			blink_delay = servertime + 0.4;
+	}
+
+	return blink_delay < servertime;
+};
+
+//
+// HUD_Powerups()
+// Draws powerups (Instakill, Double Points) to
+// the screen. Correctly handles blink delay.
+// 
 void() HUD_Powerups =
 {
-	float count = 0;
+	float y = g_height - 38;
+	float scale = 32;
 
-	// horrible way to offset check :)))))))))))))))))) :DDDDDDDD XOXO
+	// Get both the time left and the state of our powerups:
+	// Instakill first...
+	float instakill_end_time = getstatf(STAT_INSTA);
+	float instakill_active = instakill_end_time > servertime;
+	float instakill_opacity = HUD_PowerUpBlink(instakill_blink, instakill_end_time);
 
-	if (getstatf(STAT_X2))
-		count++;
+	// ...and Double Points next.
+	float x2_end_time = getstatf(STAT_X2);
+	float x2_active = x2_end_time > servertime;
+	float x2_opacity = HUD_PowerUpBlink(x2_blink, x2_end_time);
 
-	if (getstatf(STAT_INSTA))
-		count++;
-
-	// both are avail draw fixed order
-	if (count == 2) {
-		drawpic([g_width/2 - (2 + 32), g_height - 38], "gfx/hud/2x.tga", [32, 32], [1, 1, 1], 1);
-		drawpic([g_width/2 + 2, g_height - 38], "gfx/hud/in_kill.tga", [32, 32], [1, 1, 1], 1);
+	// If both of our powerups are active...
+	if (x2_active && instakill_active) {
+		// We'll want to draw whatever powerup has less time first
+		// (since that's the one that we obtained first).
+		if (instakill_end_time < x2_end_time) {
+			drawpic([g_width/2 - (2 + 32), y], "gfx/hud/in_kill.tga", [scale, scale], [1, 1, 1], instakill_opacity);
+			drawpic([g_width/2 + 2, y], "gfx/hud/2x.tga", [scale, scale], [1, 1, 1], x2_opacity);
+		} else {
+			drawpic([g_width/2 - (2 + 32), y], "gfx/hud/2x.tga", [scale, scale], [1, 1, 1], x2_opacity);
+			drawpic([g_width/2 + 2, y], "gfx/hud/in_kill.tga", [scale, scale], [1, 1, 1], instakill_opacity);
+		}
 	} else {
-		if (getstatf(STAT_X2))
-			drawpic([g_width/2 - 16, g_height - 38], "gfx/hud/2x.tga", [32, 32], [1, 1, 1], 1);
-		else if (getstatf(STAT_INSTA))
-			drawpic([g_width/2 - 16, g_height - 38], "gfx/hud/in_kill.tga", [32, 32], [1, 1, 1], 1);
+		if (instakill_active) {
+			drawpic([g_width/2 - 16, y], "gfx/hud/in_kill.tga", [scale, scale], [1, 1, 1], instakill_opacity);
+		} else if (x2_active) {
+			drawpic([g_width/2 - 16, y], "gfx/hud/2x.tga", [scale, scale], [1, 1, 1], x2_opacity);
+		}
 	}
-}
+};
 
 void() HUD_Broadcast = 
 {

--- a/source/server/defs/custom.qc
+++ b/source/server/defs/custom.qc
@@ -506,9 +506,7 @@ vector 	mystery_box_start_origin;
 
 .string powerup_vo;
 float instakill_finished;
-float insta_blink;
 float x2_finished;
-float x2_blink;
 float total_windows_down;
 float total_powerup_points;
 float powerup_score_threshold;

--- a/source/server/entities/powerups.qc
+++ b/source/server/entities/powerups.qc
@@ -366,7 +366,7 @@ void() PU_Nuke =
 void() PU_InstaKill =
 {
 	instakill_finished = time + 30;
-	other.insta_icon = true;
+	other.insta_icon = instakill_finished;
 };
 
 //
@@ -376,7 +376,7 @@ void() PU_InstaKill =
 void() PU_DoublePoints =
 {
 	x2_finished = time + 30;
-	other.x2_icon = true;
+	other.x2_icon = x2_finished;
 };
 
 //

--- a/source/server/weapons/weapon_core.qc
+++ b/source/server/weapons/weapon_core.qc
@@ -1668,44 +1668,11 @@ void () Impulse_Functions =
 	self.impulse = 0;
 };
 
-//
-// WeaponCore_PowerUpBlink(blink_delay, powerup_endtime)
-// Determines whether or not the Power-Up HUD icon should be
-// visible.
-// FIXME: This should be moved out of weapon_core, ideally.
-//
-float(__inout float blink_delay, float powerup_endtime) WeaponCore_PowerUpBlink =
-{
-	// If the Power-Up is still active
-	if (powerup_endtime >= time) {
-		float should_be_visible = false;
-
-		// If there's less than five seconds remaining,
-		// blink every 0.2s.
-		if (powerup_endtime < time + 5) {
-			if (blink_delay < time - 0.2)
-				blink_delay = time + 0.2;
-		}
-		// If there's less than 10 seconds remaining,
-		// blink every 0.4s.
-		else if (powerup_endtime < time + 10) {
-			if (blink_delay < time - 0.4)
-				blink_delay = time + 0.4;
-		}
-
-		if (blink_delay < time)
-			return true;
-	}
-
-	// End of the line, return false.
-	return false;
-};
-
 void() CheckPlayer = 
 {
-	// Update Power-Up blinking
-	self.insta_icon = WeaponCore_PowerUpBlink(insta_blink, instakill_finished);
-	self.x2_icon = WeaponCore_PowerUpBlink(x2_blink, x2_finished);
+	// Update clients with powerup times
+	self.insta_icon = instakill_finished;
+	self.x2_icon = x2_finished;
 
 	CheckRevive(self);
 


### PR DESCRIPTION
This PR moves all code relating to power-ups blinking to the client over the server. I also made some changes to the display code to match the behavior in World at War:

- Power-ups now display in the order that they are acquired, as opposed to a fixed order
- When multiple power-up icons are being displayed, blinking does not shift other icons (this was why I made this PR in the first place)

Some of the changes made in this PR will require simultaneous updates to Vril and Quakespasm since the `STAT_INSTA` and `STAT_X2` stats are now being used in a different manner - those PRs will be linked when available.