### PR TITLE
SERVER: Properly remove all weapons on game over

### DIFF
--- a/source/server/damage.qc
+++ b/source/server/damage.qc
@@ -162,7 +162,7 @@ void() EndGameSetup =
 	Player_AddScore(self, self.score, false);
 	for (float i = 0; i < MAX_PLAYER_WEAPONS; ++i)
 	{
-		Weapon_RemoveWeapon(i);
+		Weapon_RemoveWeapon(0);
 	}
   return;
 }


### PR DESCRIPTION
The code assumed the IDs of the weapons would stay the same after one is removed. Instead, loop and call Weapon_RemoveWeapon(0).

### Description of Changes
The code would only remove one weapon when dying, this fixes that

### Checklist
I tested this when dying with one weapon, two weapons, and three weapons.