### PR TITLE
SERVER: Fix Perk and Power Switch related Restart issues

### DIFF
--- a/progs/ssqc.src
+++ b/progs/ssqc.src
@@ -84,6 +84,7 @@ tests/test_weapons.qc
 tests/test_misc_model.qc
 tests/test_score.qc
 tests/test_ai.qc
+tests/test_power.qc
 tests/test_module.qc
 #endif
 #endlist

--- a/source/server/clientfuncs.qc
+++ b/source/server/clientfuncs.qc
@@ -651,6 +651,13 @@ float() crandom =
 
 float(entity them, entity me) PlayerIsLooking =
 {
+
+#ifdef QUAKEC_TEST
+
+	return true;
+
+#else
+
 	float ret = false;
 	float old_solid = me.solid;
 	me.solid = SOLID_BBOX;
@@ -674,4 +681,7 @@ float(entity them, entity me) PlayerIsLooking =
 	me.solid = old_solid;
 	setorigin(me, me.origin);
 	return ret;
+
+#endif // QUAKEC_TEST
+
 };

--- a/source/server/defs/standard.qc
+++ b/source/server/defs/standard.qc
@@ -474,3 +474,5 @@ void    (entity who, float low_frequency, float high_frequency, float duration) 
 #define		FILE_READ 	 				0
 #define		FILE_APPEND 				1
 #define		FILE_WRITE 					2
+
+void (string out) print = {bprint(PRINT_HIGH, out);}

--- a/source/server/player/player_core.qc
+++ b/source/server/player/player_core.qc
@@ -470,6 +470,14 @@ void(entity who, entity active_ent, float type, float cost, float weapon) Player
 //
 float(entity who, entity active_ent) Player_UseButtonPressed =
 {
+#ifdef QUAKEC_TEST
+
+	if (who.button7)
+		return true;
+
+	return false;
+
+#else
 	// Small delay before we can interact with a new entity to
 	// mitigate overlapping bboxes causing problems.
 	if (who.last_looked_time >= time && active_ent != who.last_looked_ent)
@@ -480,6 +488,7 @@ float(entity who, entity active_ent) Player_UseButtonPressed =
 	}
 
 	return false;
+#endif // QUAKEC_TEST
 };
 
 void() PlayerJump =
@@ -827,8 +836,9 @@ void() PlayerPostThink =
 
 #ifdef QUAKEC_TEST
 
-	if (time_before_gamestart != 0)
+	if (time_before_gamestart != 0) {
 		Test_RunAllTests();
+	}
 
 #endif // QUAKEC_TEST
 };

--- a/source/server/tests/test_module.qc
+++ b/source/server/tests/test_module.qc
@@ -57,6 +57,28 @@ void(string message) Test_Skip =
 	skipped_message_buffer = sprintf("[SKIP]: %s\n", message);
 }
 
+void(entity object) Test_SimulateUse =
+{
+	float old_power_on = isPowerOn;
+	isPowerOn = true;
+
+	entity old_self = self;
+
+	self.button7 = true;
+	self.fire_delay = self.reload_delay = self.dive_delay = self.reload_delay = self.switch_delay = 0;
+
+	self = object;
+	other = old_self;
+	object.touch();
+	self = old_self;
+	other = world;
+
+	self.button7 = false;
+	self.semi_actions &= ~SEMIACTION_USE;
+
+	isPowerOn = old_power_on;
+}
+
 void(void() test_func, string test_name) Test_Run =
 {
 	print(sprintf("[INFO]: Running test [%s]..", test_name));
@@ -107,6 +129,7 @@ var struct {
 	{ Test_Math_ClampReturnsMin, "Test_Math_ClampReturnsMin" },
 	{ Test_Math_ClampReturnsMax, "Test_Math_ClampReturnsMax" },
 	{ Test_Perks_QuickRevive_ValidateFields, "Test_Perks_QuickRevive_ValidateFields" },
+	{ Test_Perks_QuickRevive_NoCostChangeOnRestart, "Test_Perks_QuickRevive_NoCostChangeOnRestart" },
 	{ Test_Perks_JuggerNog_ValidateFields, "Test_Perks_JuggerNog_ValidateFields" },
 	{ Test_Perks_SpeedCola_ValidateFields, "Test_Perks_SpeedCola_ValidateFields" },
 	{ Test_Perks_DoubleTap_ValidateFields, "Test_Perks_DoubleTap_ValidateFields" },
@@ -115,6 +138,7 @@ var struct {
 	{ Test_Perks_DeadshotDaiquiri_ValidateFields, "Test_Perks_DeadshotDaiquiri_ValidateFields" },
 	{ Test_Perks_Random_LegacyFields, "Test_Perks_Random_LegacyFields" },
 	{ Test_Perks_MuleKick_ValidateFields, "Test_Perks_MuleKick_ValidateFields" },
+	{ Test_Perks_Drink_WorkOnReset, "Test_Perks_Drink_WorkOnReset" },
 	{ Test_Weapons_Gewehr_MagazineSize, "Test_Weapons_Gewehr_MagazineSize" },
 	{ Test_Weapons_BowieKnife_RemovedAfterRespawn, "Test_Weapons_BowieKnife_RemovedAfterRespawn" },
 	{ Test_Weapons_HoldTwoWeapons, "Test_Weapons_HoldTwoWeapons" },
@@ -131,7 +155,8 @@ var struct {
 	{ Test_AddScore_NonClient, "Test_AddScore_NonClient" },
 	{ Test_AddScore_DamageTypes, "Test_AddScore_DamageTypes" },
 	{ Test_AddScore_MysteryBoxLeave, "Test_AddScore_MysteryBoxLeave" },
-	{ Test_AI_HellhoundsDetected, "Test_AI_HellhoundsDetected" }
+	{ Test_AI_HellhoundsDetected, "Test_AI_HellhoundsDetected" },
+	{ Test_Power_HandleResetOnRestart, "Test_Power_HandleResetOnRestart" }
 };
 
 void() Test_RunAllTests =

--- a/source/server/tests/test_perksacola.qc
+++ b/source/server/tests/test_perksacola.qc
@@ -26,6 +26,9 @@
 */
 float(float condition, string message) Test_Assert;
 void(string message) Test_Skip;
+void(entity object) Test_SimulateUse;
+
+// MARK: Quick Revive
 
 //
 // Test_Perks_QuickRevive_ValidatePrice()
@@ -49,6 +52,48 @@ void() Test_Perks_QuickRevive_ValidateFields =
 };
 
 //
+// Test_Perks_QuickRevive_NoCostChangeOnRestart()
+// Validates that on a Soft_Restart the price of Quick
+// Revive does not change.
+// (https://github.com/nzp-team/nzportable/issues/1116)
+//
+void() Test_Perks_QuickRevive_NoCostChangeOnRestart =
+{
+    entity perk_revive = find(world, classname, "perk_revive");
+
+    // We need to simulate buying the perk to see the cost reduction,
+    // so give us points.
+    self.points = 10000;
+    float start_score = self.points;
+
+    // Simulate purchase
+    Test_SimulateUse(perk_revive);
+
+    float score_diff_before = start_score - self.points;
+
+    Test_Assert((score_diff_before != 0), "Could not buy Quick Revive before restart!");
+
+    Soft_Restart();
+
+    // Do everything again and then assert
+    // the diffs are the same.
+    self.points = 10000;
+    start_score = self.points;
+
+    Test_SimulateUse(perk_revive);
+
+    float score_diff_after = start_score - self.points;
+
+    Test_Assert((score_diff_before != 0), "Could not buy Quick Revive after restart!");
+    Test_Assert((score_diff_before == score_diff_after), sprintf("Quick Revive price changed after Soft_Restart, expected [%d] but got [%d]!", score_diff_before, score_diff_after));
+
+    // Restart at end of test to not cause conflicts with tests ran afterwards.
+    Soft_Restart();
+};
+
+// MARK: Jugger-Nog
+
+//
 // Test_Perks_JuggerNog_ValidatePrice()
 // Spawns a Jugger-Nog machine and validates its
 // default fields.
@@ -68,6 +113,8 @@ void() Test_Perks_JuggerNog_ValidateFields =
     self = old_self;
     remove(machine);
 };
+
+// MARK: Speed Cola
 
 //
 // Test_Perks_SpeedCola_ValidatePrice()
@@ -90,6 +137,8 @@ void() Test_Perks_SpeedCola_ValidateFields =
     remove(machine);
 };
 
+// MARK: Double Tap
+
 //
 // Test_Perks_DoubleTap_ValidateFields()
 // Spawns a Double Tap machine and validates its
@@ -110,6 +159,8 @@ void() Test_Perks_DoubleTap_ValidateFields =
     self = old_self;
     remove(machine);
 };
+
+// MARK: Stamin-Up
 
 //
 // Test_Perks_StaminUp_ValidateFields()
@@ -132,6 +183,8 @@ void() Test_Perks_StaminUp_ValidateFields =
     remove(machine);
 };
 
+// MARK: PhD Flopper
+
 //
 // Test_Perks_PhDFlopper_ValidateFields()
 // Spawns a PhD Flopper machine and validates its
@@ -152,6 +205,8 @@ void() Test_Perks_PhDFlopper_ValidateFields =
     self = old_self;
     remove(machine);
 };
+
+// MARK: Deadshot Daiquiri
 
 //
 // Test_Perks_DeadshotDaiquiri_ValidateFields()
@@ -174,6 +229,8 @@ void() Test_Perks_DeadshotDaiquiri_ValidateFields =
     remove(machine);
 };
 
+// MARK: Mule Kick
+
 //
 // Test_Perks_MuleKick_ValidateFields()
 // Spawns a Deadshot Daiquiri machine and validates its
@@ -195,6 +252,8 @@ void() Test_Perks_MuleKick_ValidateFields =
     remove(machine);
 };
 
+// MARK: Random Perk
+
 //
 // Test_Perks_Random_LegacyFields()
 // Attempts to spawn a random Perk-A-Cola
@@ -212,4 +271,20 @@ void() Test_Perks_Random_LegacyFields =
     self = old_self;
 
     remove(random);
+};
+
+// MARK: Misc.
+
+//
+// Test_Perks_Drink_WorkOnReset()
+// Verifies that drinking a Perk and then
+// triggering a Soft_Restart does not
+// prevent purchase of additional Perks.
+// (https://github.com/nzp-team/nzportable/issues/1126)
+// 
+void() Test_Perks_Drink_WorkOnReset =
+{
+    self.isBuying = true;
+    Soft_Restart();
+    Test_Assert((self.isBuying == false), "isBuying state not reset!");
 };

--- a/source/server/tests/test_power.qc
+++ b/source/server/tests/test_power.qc
@@ -1,0 +1,49 @@
+/*
+	server/tests/test_power.qc
+
+	Unit tests for the Power Switch
+
+	Copyright (C) 2021-2025 NZ:P Team
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+	See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to:
+
+		Free Software Foundation, Inc.
+		59 Temple Place - Suite 330
+		Boston, MA  02111-1307, USA
+
+*/
+float(float condition, string message) Test_Assert;
+void(string message) Test_Skip;
+
+//
+// Test_Power_HandleResetOnRestart()
+// Turns on the Power and validates the
+// Power Switch handle's angles are reset
+// on Soft_Restart.
+// (https://github.com/nzp-team/nzportable/issues/1125)
+//
+void() Test_Power_HandleResetOnRestart =
+{
+    entity power_switch = find(world, classname, "power_switch");
+
+    Test_Assert((power_switch.boxweapon.angles == power_switch.angles), "Power Switch handle angles are not correct at start of test!");
+    
+    // Simulated switch flip
+    power_switch.boxweapon.angles_x += 180;
+
+    Soft_Restart();
+
+    Test_Assert((power_switch.boxweapon.angles == power_switch.angles), "Power Switch handle angles are not correct at end of test!");
+};

--- a/source/server/utilities/game_restart.qc
+++ b/source/server/utilities/game_restart.qc
@@ -171,6 +171,9 @@ void() GameRestart_ResetMysteryBox =
 	// Check if there is a Mystery Box in the map
 	entity mystery_box = find(world, classname, "mystery");
 
+	if (mystery_box.boxstatus == 0 && mystery_box.frame == 0 && mystery_box.spins == 0)
+		return;
+
 	if (mystery_box != world) {
 		mystery_box.boxstatus = 0;
 		mystery_box.frame = 0;
@@ -284,6 +287,25 @@ void() GameRestart_OpenClosedDoors =
 	}
 }
 
+//
+// GameRestart_ResetPower()
+// Turns off Power and resets Power Switch state.
+//
+void() GameRestart_ResetPower =
+{
+	entity power_switch;
+	power_switch = find(world, classname, "power_switch");
+
+	if (power_switch) {
+		isPowerOn = false;
+		power_switch.frame = 0;
+
+		if (!(power_switch.spawnflags & 1)) {
+			power_switch.boxweapon.angles = power_switch.angles;
+		}
+	}
+};
+
 void() Soft_Restart = {
 	entity who, oldself, endgame;
 	self = find(world,classname,"player");
@@ -320,6 +342,7 @@ void() Soft_Restart = {
 	GameRestart_ResetMysteryBox();		// Clean up the Mystery Box, delete floating weapon, etc.
 	GameRestart_RestoreFakeRemovals();	// Puts back everything "removed" using Ent_FakeRemove().
 	GameRestart_OpenClosedDoors(); 		// Restores doors that were previously opened in last session.
+	GameRestart_ResetPower();			// Turns off Power and resets Power Switch state.
 
 	//reset buyable ending
 	endgame = find(world, classname, "func_ending");
@@ -339,18 +362,13 @@ void() Soft_Restart = {
 		tp.think = SUB_Null;
 	}
 
-	local entity power;
-	power = find(world, classname, "power_switch");
-	if(power) {
-		isPowerOn = false;
-		power.frame = 0;
-	}
-
 	self = oldself;
 	self.downed = 0;
 	self.progress_bar = 0;
 	self.progress_bar_time = 0;
 	self.progress_bar_percent = 0;
+	self.isBuying = false;
+	self.style = 0;
 	in_endgame_sequence = false;
 	rounds = 0;
 	self.score = 0;
@@ -364,6 +382,8 @@ void() Soft_Restart = {
 	self.secondary_grenades = 0;
 	self.grenades = 1;
 	self.pri_grenade_state = 0;
+
+	player_count = 0;
 
 	InitRounds();
 	PutClientInServer();


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Fixes the following Soft_Restart related problems and drafts unit tests to reproduce them:
* https://github.com/nzp-team/nzportable/issues/1116
* https://github.com/nzp-team/nzportable/issues/1125
* https://github.com/nzp-team/nzportable/issues/1126
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
See builds for passing unit tests
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
