### PR TITLE
MENU: Support GamePad sensitivity settings

### DIFF
--- a/source/menu/menu_gpad.qc
+++ b/source/menu/menu_gpad.qc
@@ -1,4 +1,4 @@
-string menu_gpad_buttons[5] = {"gp_glyp", "gp_rumb", "gp_aima", "gp_apply", "gp_back"};
+string menu_gpad_buttons[7] = {"gp_glyp", "gp_rumb", "gp_aima", "gp_senx", "gp_seny", "gp_apply", "gp_back"};
 
 void() Menu_Gamepad_ApplyGlpyh =
 {
@@ -119,6 +119,12 @@ void() Menu_Gamepad =
         default: break;
     }
     Menu_DrawOptionValue(3, aa_string);
+
+    Menu_Button(4, "gp_senx", "X AXIS SENSITIVITY", "Alter X-Axis Look Sensitivity.") ? 0 : 0;
+    Menu_CvarSlider(4, [0, 4, 16], "joypitchsensitivity", false, false);
+
+    Menu_Button(5, "gp_seny", "Y AXIS SENSITIVITY", "Alter Y-Axis Look Sensitivity.") ? 0 : 0;
+    Menu_CvarSlider(5, [0, 4, 16], "joyyawsensitivity", false, false);
 
     Menu_DrawDivider(12.25);
     Menu_Button(-2, "gp_apply", "APPLY", "Save & Apply Settings.") ? Menu_Gamepad_ApplySettings() : 0;


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Adds options for gamepad per-axis sensitivity to MenuQC.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
![image](https://github.com/user-attachments/assets/bbb7e303-51ff-4366-a9ca-e9d5e6399cdf)

<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
