### PR TITLE
SERVER: Stop Game Over Sequence on Soft_Restart

### DIFF
--- a/progs/ssqc.src
+++ b/progs/ssqc.src
@@ -85,6 +85,7 @@ tests/test_misc_model.qc
 tests/test_score.qc
 tests/test_ai.qc
 tests/test_power.qc
+tests/test_misc.qc
 tests/test_module.qc
 #endif
 #endlist

--- a/source/server/tests/test_misc.qc
+++ b/source/server/tests/test_misc.qc
@@ -1,0 +1,56 @@
+/*
+	server/tests/test_misc.qc
+
+	Hard to categorize tests.
+
+	Copyright (C) 2021-2025 NZ:P Team
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+	See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to:
+
+		Free Software Foundation, Inc.
+		59 Temple Place - Suite 330
+		Boston, MA  02111-1307, USA
+
+*/
+float(float condition, string message) Test_Assert;
+void(string message) Test_Skip;
+
+//
+// Test_EndGame_CounterResetsOnRestart()
+// Validate that the End Game counter is
+// reset on Soft_Restart, so that the game
+// does not unexpectedly end.
+// (https://github.com/nzp-team/nzportable/issues/1112)
+//
+void() Test_EndGame_CounterResetsOnRestart =
+{
+    entity gameover_watcher;
+
+    // Start End Game sequence
+    EndGameSetup();
+
+    // Validate we can find "gameover_watcher"
+    gameover_watcher = find(world, classname, "gameover_watcher");
+
+    Test_Assert((gameover_watcher != world), "Could not find the Game Over Watcher!");
+
+    // Restart the level.
+    Soft_Restart();
+
+    gameover_watcher = find(world, classname, "gameover_watcher");
+
+    // Game Over Watcher should be despawned.
+    Test_Assert((gameover_watcher == world), "Game Over Watcher still exists!");
+};

--- a/source/server/tests/test_module.qc
+++ b/source/server/tests/test_module.qc
@@ -156,7 +156,8 @@ var struct {
 	{ Test_AddScore_DamageTypes, "Test_AddScore_DamageTypes" },
 	{ Test_AddScore_MysteryBoxLeave, "Test_AddScore_MysteryBoxLeave" },
 	{ Test_AI_HellhoundsDetected, "Test_AI_HellhoundsDetected" },
-	{ Test_Power_HandleResetOnRestart, "Test_Power_HandleResetOnRestart" }
+	{ Test_Power_HandleResetOnRestart, "Test_Power_HandleResetOnRestart" },
+	{ Test_EndGame_CounterResetsOnRestart, "Test_EndGame_CounterResetsOnRestart" }
 };
 
 void() Test_RunAllTests =

--- a/source/server/utilities/game_restart.qc
+++ b/source/server/utilities/game_restart.qc
@@ -307,7 +307,7 @@ void() GameRestart_ResetPower =
 };
 
 void() Soft_Restart = {
-	entity who, oldself, endgame;
+	entity who, oldself, endgame, game_over;
 	self = find(world,classname,"player");
 	oldself = self;
 	
@@ -348,6 +348,12 @@ void() Soft_Restart = {
 	endgame = find(world, classname, "func_ending");
 	if (endgame) {
 		endgame.activated = false;
+	}
+
+	// Restart End Game sequence
+	game_over = find(world, classname, "gameover_watcher");
+	if (game_over) {
+		remove(game_over);
 	}
 
 	//reset teleporters


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Fixes an issue where we would not stop the Game Over sequence if we restart the current level.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
