### PR TITLE
SERVER: Update frame calls for new Bowie Knife

### DIFF
--- a/source/server/entities/wall_weapon.qc
+++ b/source/server/entities/wall_weapon.qc
@@ -326,6 +326,7 @@ void () WallWeapon_TouchTrigger =
 					W_HideCrosshair(other);
 					Player_RemoveScore(other, self.cost2);
 					Sound_PlaySound(other, "sounds/misc/ching.wav", SOUND_TYPE_ENV_CHING, SOUND_PRIORITY_PLAYALWAYS);
+					Sound_PlaySound(other, "sounds/weapons/knife/bowie.wav", SOUND_TYPE_WEAPON_OTHER, SOUND_PRIORITY_PLAYALWAYS);
 					other.ach_tracker_coll++;
 					if (self.enemy)
 					{
@@ -334,7 +335,7 @@ void () WallWeapon_TouchTrigger =
 					entity tempz;
 					tempz = self;
 					self = other;
-					Set_W_Frame(15, 30, 2.75, 0, 0, W_PlayTakeOut, "models/weapons/knife/v_bowie.mdl", false, S_BOTH, true);
+					Set_W_Frame(16, 43, 2.75, 0, 0, W_PlayTakeOut, "models/weapons/knife/v_bowie.mdl", false, S_BOTH, true);
 					self.has_bowie_knife = true;
 				}
 			}

--- a/source/shared/weapon_stats.qc
+++ b/source/shared/weapon_stats.qc
@@ -3762,6 +3762,9 @@ void(float weptype) precache_extra =
 		case W_BETTY:
 			precache_model("models/weapons/grenade/g_betty.mdl");
 			break;
+		case W_BOWIE:
+			precache_sound("sounds/weapons/knife/bowie.wav");
+			break;
 	}
 }
 
@@ -4676,8 +4679,8 @@ float(float weapon) WepDef_GetWeaponMeleeRange =
 // FIXME -- data-drive these.
 #define MELEE_BOWIE_FIRST_FRAME_NORMAL 	0
 #define MELEE_BOWIE_LAST_FRAME_NORMAL	3
-#define MELEE_BOWIE_FIRST_FRAME_LUNGED	4
-#define MELEE_BOWIE_LAST_FRAME_LUNGED	10
+#define MELEE_BOWIE_FIRST_FRAME_LUNGED	5
+#define MELEE_BOWIE_LAST_FRAME_LUNGED	15
 #define MELEE_BOWIE_DURATION_NORMAL		0.65
 #define MELEE_BOWIE_DURATION_LUNGED		1.0
 #define MELEE_BOWIE_VIEWMODEL_PATH 		"models/weapons/knife/v_bowie.mdl"


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
https://github.com/nzp-team/assets/pull/101 requires some changes to the frame counts for Bowie Knife playback, this implements that as well as adds support for the inspect sound.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
https://github.com/user-attachments/assets/e195520e-bfa5-4f43-aa9c-39ca30108bac
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
