### PR TITLE
SERVER: Fix flamethrower appearing in loot pool & allow duplicates assuming they are not 2 slots within each other

### DIFF
--- a/source/server/gamemodes/gun_game.qc
+++ b/source/server/gamemodes/gun_game.qc
@@ -53,7 +53,7 @@ float(float weapon_id, float current_index) Gamemode_GunGame_WeaponIDIsValid =
     if (weapon_id == W_M2)
         return false;
 
-    // Don't allow duplicates in the last 2 weapons only
+    // Prevent duplicates if the weapon appeared in the previous 2 slots
     float prev1 = current_index - 1;
     float prev2 = current_index - 2;
 

--- a/source/server/gamemodes/gun_game.qc
+++ b/source/server/gamemodes/gun_game.qc
@@ -73,9 +73,8 @@ void() Gamemode_GunGame_GenerateWeaponList =
 {
     for (float i = 0; i < GUNGAME_MAX_WEAPONS; i++) {
         float found_eligible_weapon = false;
-        float tries = 0;
 
-        while (!found_eligible_weapon && tries < 1000) {
+        while (!found_eligible_weapon) {
             float weapon_id = rint(random() * 59);
             float final_id = EqualNonPapWeapon(weapon_id);
 
@@ -83,7 +82,6 @@ void() Gamemode_GunGame_GenerateWeaponList =
                 gungame_weapon_pool[i] = final_id;
                 found_eligible_weapon = true;
             }
-            tries++;
         }
     }
 };

--- a/source/server/gamemodes/gun_game.qc
+++ b/source/server/gamemodes/gun_game.qc
@@ -41,7 +41,7 @@ float gungame_ran_post_init_logic;
 
 void() info_gungame_nukespot = {};
 
-float(float weapon_id) Gamemode_GunGame_WeaponIDIsValid =
+float(float weapon_id, float current_index) Gamemode_GunGame_WeaponIDIsValid =
 {
     // Non-weapons should be excluded.
     if (weapon_id == W_NOWEP || weapon_id == W_GRENADE ||
@@ -53,9 +53,16 @@ float(float weapon_id) Gamemode_GunGame_WeaponIDIsValid =
     if (weapon_id == W_M2)
         return false;
 
-    // Don't allow duplicates.
-    for (float i = 0; i < GUNGAME_MAX_WEAPONS; i++) {
-        if (gungame_weapon_pool[i] == weapon_id)
+    // Don't allow duplicates in the last 2 weapons only
+    float prev1 = current_index - 1;
+    float prev2 = current_index - 2;
+
+    if (prev1 >= 0 && prev1 < GUNGAME_MAX_WEAPONS) {
+        if (gungame_weapon_pool[prev1] == weapon_id)
+            return false;
+    }
+    if (prev2 >= 0 && prev2 < GUNGAME_MAX_WEAPONS) {
+        if (gungame_weapon_pool[prev2] == weapon_id)
             return false;
     }
 
@@ -72,7 +79,7 @@ void() Gamemode_GunGame_GenerateWeaponList =
             float weapon_id = rint(random() * 59);
             float final_id = EqualNonPapWeapon(weapon_id);
 
-            if (Gamemode_GunGame_WeaponIDIsValid(final_id)) {
+            if (Gamemode_GunGame_WeaponIDIsValid(final_id, i)) {
                 gungame_weapon_pool[i] = final_id;
                 found_eligible_weapon = true;
             }

--- a/source/server/gamemodes/gun_game.qc
+++ b/source/server/gamemodes/gun_game.qc
@@ -66,14 +66,17 @@ void() Gamemode_GunGame_GenerateWeaponList =
 {
     for (float i = 0; i < GUNGAME_MAX_WEAPONS; i++) {
         float found_eligible_weapon = false;
+        float tries = 0;
 
-        while (!found_eligible_weapon) {
+        while (!found_eligible_weapon && tries < 1000) {
             float weapon_id = rint(random() * 59);
+            float final_id = EqualNonPapWeapon(weapon_id);
 
-            if (Gamemode_GunGame_WeaponIDIsValid(weapon_id)) {
-                gungame_weapon_pool[i] = EqualNonPapWeapon(weapon_id);
+            if (Gamemode_GunGame_WeaponIDIsValid(final_id)) {
+                gungame_weapon_pool[i] = final_id;
                 found_eligible_weapon = true;
             }
+            tries++;
         }
     }
 };


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
This PR removes the flamethrower from the gun game weapon pool, and allows duplicates assuming they are not 2 slots within each other, since there's only 26 unique guns excluding the flamethrower.

The visual example is in solo play, but I also tested multiplayer, and did not notice any issues.

Closes https://github.com/nzp-team/nzportable/issues/1184

### Visual Sample
---
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

https://github.com/user-attachments/assets/b55efb91-4633-443c-92ed-8e25b6a3a877




### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
