### PR TITLE
SERVER: Ensure `PlayerSpawn()` only resets rounds when appropriate

### DIFF
--- a/progs/ssqc.src
+++ b/progs/ssqc.src
@@ -88,6 +88,7 @@ gamemodes/core.qc
 tests/test_math.qc
 tests/test_perksacola.qc
 tests/test_weapons.qc
+tests/test_rounds.qc
 tests/test_misc_model.qc
 tests/test_score.qc
 tests/test_ai.qc

--- a/source/server/player/player_core.qc
+++ b/source/server/player/player_core.qc
@@ -1094,7 +1094,7 @@ void() PlayerSpawn =
 
 #endif // FTE
 
-	rounds = cvar("sv_startround") - 1;
+	if (rounds < cvar("sv_startround")) rounds = cvar("sv_startround") - 1;
 	if (rounds < 0) rounds = 0;
 
 	// Make sure players joining after game start are still allowed

--- a/source/server/tests/test_module.qc
+++ b/source/server/tests/test_module.qc
@@ -157,7 +157,8 @@ var struct {
 	{ Test_AddScore_MysteryBoxLeave, "Test_AddScore_MysteryBoxLeave" },
 	{ Test_AI_HellhoundsDetected, "Test_AI_HellhoundsDetected" },
 	{ Test_Power_HandleResetOnRestart, "Test_Power_HandleResetOnRestart" },
-	{ Test_EndGame_CounterResetsOnRestart, "Test_EndGame_CounterResetsOnRestart" }
+	{ Test_EndGame_CounterResetsOnRestart, "Test_EndGame_CounterResetsOnRestart" },
+	{ Test_Round_PlayerSpawnSetsRoundProperly, "Test_Round_PlayerSpawnSetsRoundProperly" }
 };
 
 void() Test_RunAllTests =

--- a/source/server/tests/test_rounds.qc
+++ b/source/server/tests/test_rounds.qc
@@ -1,0 +1,58 @@
+/*
+	server/tests/test_rounds.qc
+
+	Unit tests related to rounds.
+
+	Copyright (C) 2021-2025 NZ:P Team
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+	See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to:
+
+		Free Software Foundation, Inc.
+		59 Temple Place - Suite 330
+		Boston, MA  02111-1307, USA
+
+*/
+float(float condition, string message) Test_Assert;
+void(string message) Test_Skip;
+
+//
+// Test_Round_PlayerSpawnSetsRoundProperly()
+// Validate that PlayerSpawn() only sets the round when needed (at the game start).
+// This prevents the round resetting whenever a player joins the game.
+// (https://github.com/nzp-team/nzportable/issues/1185)
+//
+void() Test_Round_PlayerSpawnSetsRoundProperly =
+{
+	float backup_round, backup_startround;
+
+	// Backup our rounds / start round, and then set them.
+	backup_round = rounds;
+    backup_startround = cvar("sv_startround");
+    rounds = 21;
+    cvar_set("sv_startround", "0");
+
+    // Make sure that our rounds value is still 21.
+    PlayerSpawn();
+    Test_Assert(rounds == 21, "Rounds value is being incorrectly reset!");
+
+    // Make sure that a negative round value properly sets as well.
+    rounds = -3;
+    PlayerSpawn();
+    Test_Assert(rounds == 0, "Rounds value is not being correctly reset!");
+
+    // Restore original values.
+    rounds = backup_round;
+    cvar_set("sv_startround", ftos(backup_startround));
+};


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Adds an additional guard for rounds being updated in `PlayerSpawn()` so that rounds aren't erroneously reset when a player joins a multiplayer game (https://github.com/nzp-team/nzportable/issues/1185). Also adds a relevant unit test in a file for round-specific logic.

### Visual Sample
---

https://github.com/user-attachments/assets/08b9526c-6091-4692-b42d-49f97e4c3d21

### Checklist
---

- [X] I have thoroughly tested my changes to the best of my ability
- [X] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
