### PR TITLE
nzp-team/nzportable#1185 - Do not reset round state on PlayerSpawn

### DIFF
--- a/progs/ssqc.src
+++ b/progs/ssqc.src
@@ -93,6 +93,7 @@ tests/test_score.qc
 tests/test_ai.qc
 tests/test_power.qc
 tests/test_misc.qc
+tests/test_rounds.qc
 tests/test_module.qc
 #endif
 #endlist

--- a/source/server/player/player_core.qc
+++ b/source/server/player/player_core.qc
@@ -1094,8 +1094,9 @@ void() PlayerSpawn =
 
 #endif // FTE
 
-	rounds = cvar("sv_startround") - 1;
-	if (rounds < 0) rounds = 0;
+	if (!rounds) {
+		rounds = clamp(cvar("sv_startround") - 1, 0, 1000);
+	}
 
 	// Make sure players joining after game start are still allowed
 	// to see their name.

--- a/source/server/tests/test_module.qc
+++ b/source/server/tests/test_module.qc
@@ -157,7 +157,8 @@ var struct {
 	{ Test_AddScore_MysteryBoxLeave, "Test_AddScore_MysteryBoxLeave" },
 	{ Test_AI_HellhoundsDetected, "Test_AI_HellhoundsDetected" },
 	{ Test_Power_HandleResetOnRestart, "Test_Power_HandleResetOnRestart" },
-	{ Test_EndGame_CounterResetsOnRestart, "Test_EndGame_CounterResetsOnRestart" }
+	{ Test_EndGame_CounterResetsOnRestart, "Test_EndGame_CounterResetsOnRestart" },
+	{ Test_Rounds_NewClientsDontCauseReset, "Test_Rounds_NewClientsDontCauseReset" }
 };
 
 void() Test_RunAllTests =

--- a/source/server/tests/test_rounds.qc
+++ b/source/server/tests/test_rounds.qc
@@ -1,0 +1,45 @@
+/*
+	server/tests/test_rounds.qc
+
+	Unit tests for Round logic.
+
+	Copyright (C) 2021-2025 NZ:P Team
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+	See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to:
+
+		Free Software Foundation, Inc.
+		59 Temple Place - Suite 330
+		Boston, MA  02111-1307, USA
+
+*/
+float(float condition, string message) Test_Assert;
+void(string message) Test_Skip;
+
+//
+// Test_Rounds_NewClientsDontCauseReset()
+// Asserts that a client spawning into the world does not alter
+// round logic.
+// (https://github.com/nzp-team/nzportable/issues/1185)
+//
+void() Test_Rounds_NewClientsDontCauseReset =
+{
+    float old_rounds = rounds;
+    rounds = 100;
+
+    PlayerSpawn();
+
+    Test_Assert((rounds == 100), "PlayerSpawn function reset Round!");
+    rounds = old_rounds;
+};


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Fixes an oversight where `PlayerSpawn` setting the round to `sv_startround` was ungated so would occur whenever a new client joined, or when a player respawned. Fixes https://github.com/nzp-team/nzportable/issues/1185
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
