### PR TITLE
nzp-team/nzportable#1186 - Do not reset perk_random Perk state on ResetPerkaColas

### DIFF
--- a/source/server/entities/perk_a_cola.qc
+++ b/source/server/entities/perk_a_cola.qc
@@ -659,6 +659,11 @@ void(string perk_classname, void() spawnfunc) Perk_RandomAssign =
 	else {
 		setorigin(machine, self.origin);
 		machine.angles = self.angles;
+
+		// .oldorigin is used by resets or updates, we do not
+		// want to teleport the machine back to its idle state
+		// whenever a client joins.
+		machine.oldorigin = machine.origin;
 	}
 }
 

--- a/source/server/tests/test_module.qc
+++ b/source/server/tests/test_module.qc
@@ -137,6 +137,7 @@ var struct {
 	{ Test_Perks_PhDFlopper_ValidateFields, "Test_Perks_PhDFlopper_ValidateFields" },
 	{ Test_Perks_DeadshotDaiquiri_ValidateFields, "Test_Perks_DeadshotDaiquiri_ValidateFields" },
 	{ Test_Perks_Random_LegacyFields, "Test_Perks_Random_LegacyFields" },
+	{ Test_Perks_Random_ResetDoesNotTeleport, "Test_Perks_Random_ResetDoesNotTeleport" },
 	{ Test_Perks_MuleKick_ValidateFields, "Test_Perks_MuleKick_ValidateFields" },
 	{ Test_Perks_Drink_WorkOnReset, "Test_Perks_Drink_WorkOnReset" },
 	{ Test_Weapons_Gewehr_MagazineSize, "Test_Weapons_Gewehr_MagazineSize" },

--- a/source/server/tests/test_perksacola.qc
+++ b/source/server/tests/test_perksacola.qc
@@ -273,6 +273,46 @@ void() Test_Perks_Random_LegacyFields =
     remove(random);
 };
 
+//
+// Test_Perks_Random_ResetDoesNotTeleport()
+// Asserts that if GameRestart_ResetPerkaColas() is called,
+// machines set by perk_random are not teleported to
+// their original positions.
+// (https://github.com/nzp-team/nzportable/issues/1186)
+//
+void() Test_Perks_Random_ResetDoesNotTeleport =
+{
+    entity deadshot, random;
+    entity old_self = self;
+
+    // Spawn Deadshot Daiquiri at world origin
+    deadshot = spawn();
+    self = deadshot;
+    perk_deadshot();
+    setorigin(self, '0 0 0');
+
+    // Spawn a perk_random at client's origin
+    random = spawn();
+    self = random;
+    self.spawnflags = SPAWNFLAG_PERKRANDOM_DEADSHOT; // Put Deadshot Daiquiri here!
+    perk_random();
+    setorigin(random, old_self.origin);
+
+    // Activate perk_random
+    Perk_RandomDecide();
+
+    // Call GameRestart_ResetPerkaColas, Deadshot Daiquiri should not
+    // be reset to world origin..
+    GameRestart_ResetPerkaColas();
+
+    Test_Assert((deadshot.origin != '0 0 0'), "Deadshot Daiquiri was moved to world origin!");
+
+    self = old_self;
+
+    remove(deadshot);
+    remove(random);
+};
+
 // MARK: Misc.
 
 //


### PR DESCRIPTION
…etPerkaColas

<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Whenever a new client joins, `GameRestart_ResetPerkaColas` is executed to update their states (such as Co-Op/Solo cost, or powered on state). This had the side effect of resetting the position of machines placed by `perk_random` to their original idle state. Fixes nzp-team/nzportable#1186
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
