### PR TITLE
nzp-team/nzportable#1187 - Make maxclients match maxplayers in MenuQC

### DIFF
--- a/source/menu/menu_coop.qc
+++ b/source/menu/menu_coop.qc
@@ -226,6 +226,8 @@ void() Menu_Coop_Create =
 	Menu_Button(-1, "ccm_back", "BACK", "Return to Co-Op Menu.") ? current_menu = MENU_COOP : 0;
 
 	sui_pop_frame();
+
+	cvar_set("maxclients", cvar_string("maxplayers"));
 };
 
 void() Menu_Coop_EnterCreate =


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
The Create Game menu on FTE sets `maxplayers` but not `maxclients`, which prevented more than 4 clients from joining. This sets `maxclients` to always match `maxplayers`. Fixes nzp-team/nzportable#1187
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
![image](https://github.com/user-attachments/assets/1d028ce3-fa2f-4ca9-9e47-36eb3bd9a88d)

<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
