### PR TITLE
CLIENT: Set movement flags for gamepad controls

### DIFF
--- a/source/client/main.qc
+++ b/source/client/main.qc
@@ -889,8 +889,26 @@ noref float(float evtype, float scanx, float chary, float devid) CSQC_InputEvent
 		return FALSE;
 
 	// Ignore subtle (drift-y) joystick axes
-	if (evtype == IE_JOYAXIS && devid > 0 && fabs(chary) < 0.1) {
-		return FALSE;
+	if (evtype == IE_JOYAXIS && devid > 0)
+	{
+		if (scanx == 0)
+		{
+			K_LEFTDOWN = (chary < -0.1);
+			K_RIGHTDOWN = (chary > 0.1);
+			return FALSE;
+		}
+
+		if (scanx == 1)
+		{
+			K_FORWARDDOWN = (chary < -0.1);
+			K_BACKDOWN = (chary > 0.1);
+			return FALSE;
+		}
+
+		if (fabs(chary) < 0.1)
+		{
+			return FALSE;
+		}
 	}
 
 	last_input_deviceid = devid;


### PR DESCRIPTION
### Description of Changes
---

The movement check for the crosshair was only picking up input when using keyboard controls (assuming default settings). This adds the movement flags to the left analog stick.

### Visual Sample
---

Tested on Windows with Xbox Series X Controller

Before:

https://github.com/user-attachments/assets/7a78570a-ebcd-475d-8146-959666de926b

After:

https://github.com/user-attachments/assets/17068d3c-9ff0-4718-9e50-c44392e6572b

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
