### PR TITLE
SERVER: Fixed fall damage formula incorrectly dealing max damage at all distances

### DIFF
--- a/source/server/weapons/weapon_core.qc
+++ b/source/server/weapons/weapon_core.qc
@@ -1795,13 +1795,13 @@ void() CheckPlayer =
 			self.dive = 0;
 		}
 
-		if (dist + 64 > 176 && !(self.perks & P_FLOP)) {
-			float height = dist + 64;
-			float damage = height*(0.68);
-
+        float height = dist + 64;
+		if (height > 176 && !(self.perks & P_FLOP)) {
+			float over = height - 176;
+            float damage = over * 0.68;
 			if (damage > 98) damage = 98;
 			
-			DamageHandler (self, other, damage, DMG_TYPE_OTHER);	
+			DamageHandler (self, other, damage, DMG_TYPE_OTHER); 
 
 			if (self.health <= 5)
 				GiveAchievement(7, self);	


### PR DESCRIPTION
### Description of Changes
---
The fall damage formula previously always dealt the maximum damage of 98 due to the damage not being subtracted by 176 (the minimum fall damage distance)
This PR fixes that by using the height minus 176 when applying the damage formula.

### Visual Sample
---
In the previous behavior, a fall from any height over 176 dealt 98 damage, but in the new behavior, the damage scales by height.

(look top-left showing the damage after falling)
Previous behavior:
https://github.com/user-attachments/assets/b9e61a07-1b4d-4af8-adb0-32e2a88cd95b
New behavior:
https://github.com/user-attachments/assets/a293498a-d8db-45d6-9226-d6c37b85884a
### Checklist
---

- [X] I have thoroughly tested my changes to the best of my ability
- [X] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
