### PR TITLE
SERVER: Make rays always shoot from the same location; scale down rays

### DIFF
--- a/source/server/weapons/ray_gun.qc
+++ b/source/server/weapons/ray_gun.qc
@@ -189,16 +189,7 @@ void() W_FireRay =
     // final setup!
 	porter.origin = self.origin + self.view_ofs;
 	porter.origin += v_forward * 0;
-
-	// Start at the barrel offset if not ADS
-	if (self.zoom == 0) {
-		makevectors(self.v_angle);
-		// Y, Z, X
-		vector ads_pos = GetWeaponFlash_Offset(self.weapon);
-		porter.origin += v_right * (ads_pos.x/1000);
-    	porter.origin += v_up * (ads_pos.y/1000);
-    	porter.origin += v_forward * (ads_pos.z/1000);
-	}
+	porter.scale = 0.33;
 
 	setorigin(porter, porter.origin);
 


### PR DESCRIPTION
### Description of Changes
---
Removes the code that places the ray beam at the tip of the Ray Gun's barrel when firing from the hip. This means that it will always fire from the player's head. To combat some of the visual oddities from this, the scale of the beam projectiles themselves are shrunken.

### Visual Sample
---

https://github.com/user-attachments/assets/0aa8726e-607f-44c2-8b0c-b4b720476e80


### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
