### PR TITLE
SERVER: Stop player from sprinting when free perk is picked up

### DIFF
--- a/source/server/entities/powerups.qc
+++ b/source/server/entities/powerups.qc
@@ -665,6 +665,7 @@ void() PU_FreePerk =
 
 		tempe = self;
 		self = players;
+		W_SprintStop();
 		DrinkPerk();
 		self = tempe;
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Adds W_SprintStop() to the free perk powerup logic to stop the player from continuing to sprint when they pick up a free perk, fixing the bug where you could cancel the perk animation and not get your perk.

Closes https://github.com/nzp-team/nzportable/issues/1248

### Visual Sample
---

https://github.com/user-attachments/assets/7b2691f9-d34a-4223-b897-086f4f17ebb4



### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
