### PR TITLE
nzportable/nzp-team#1196 / nzportable/nzp-team#1196 - Ballistic Knife reliability and stability fixes

### DIFF
--- a/source/server/ai/zombie_core.qc
+++ b/source/server/ai/zombie_core.qc
@@ -2008,6 +2008,8 @@ void(entity where) spawn_a_zombieB =
 	if (map_compatibility_mode == MAP_COMPAT_BETA)
 		szombie.head.scale = szombie.larm.scale = szombie.rarm.scale = szombie.scale = 0.73;
 
+	szombie.head.flags = szombie.larm.flags = szombie.rarm.flags = FL_MONSTER;
+
 	// set up timer for next spawn
 	zombie_spawn_timer = zombie_spawn_delay + time;
 

--- a/source/server/weapons/ballistic_knife.qc
+++ b/source/server/weapons/ballistic_knife.qc
@@ -32,15 +32,19 @@ void(entity victim) Blade_Damage =
     float damage_type = 0;
     float damage_region = 0;
 
+	entity damage_target = victim;
+
     switch(victim.classname) {
 		case "ai_zombie_head":
             damage_region = HEAD_X;
             damage_type = DMG_TYPE_HEADSHOT;
+			damage_target = victim.owner;
 			break;
 		case "ai_zombie_larm":
 		case "ai_zombie_rarm":
             damage_region = LIMBS_X;
             damage_type = DMG_TYPE_OTHER;
+			damage_target = victim.owner;
 			break;
 		case "ai_zombie":
 			if (trace_endpos_z < victim.origin_z) {
@@ -58,7 +62,7 @@ void(entity victim) Blade_Damage =
 			break;
 	}
 
-    DamageHandler(victim, self.owner, getWeaponDamage(self.weapon) * getWeaponMultiplier(self.weapon, damage_region), damage_type);
+    DamageHandler(damage_target, self.owner, getWeaponDamage(self.weapon) * getWeaponMultiplier(self.weapon, damage_region), damage_type);
     self.angles_y = 180;
 };
 
@@ -146,6 +150,8 @@ void() Blade_Impact =
     self.effects = EF_FULLBRIGHT;
     self.think = Blade_Die;
     self.nextthink = time + 60;
+
+	setorigin(self, self.origin);
 };
 
 //

--- a/source/server/weapons/frames_core.qc
+++ b/source/server/weapons/frames_core.qc
@@ -56,14 +56,12 @@ void () W2_Frame_Update =
 	if (self.anim_weapon2_time > time)
 		return; //don't call every frame, if it is the animations will play too fast
 
-#ifndef FTE
-
-	if (self.weapon == W_KAR_SCOPE || self.weapon == W_HEADCRACKER) {
+	// Weapons where their secondary model is an attachment (e.g. scoped kar, ballistic knife, etc.)
+	// should update the second frame in time with the first, always.
+	if (WepDef_WeaponSecondaryModelIsAttachment(self.weapon)) {
 		self.weapon2frame = self.weaponframe;
 		return;
 	}
-
-#endif // FTE
 	
 	self.anim_weapon2_time = time + self.weapon2_animduration;
 

--- a/source/shared/weapon_stats.qc
+++ b/source/shared/weapon_stats.qc
@@ -5095,3 +5095,24 @@ vector(float weapon) WepDef_GetLeftFlashOffset =
     }
     return [0, 0, 0];
 }
+
+//
+// WepDef_WeaponSecondaryModelIsAttachment(weapon)
+// Returns TRUE if a weapon's secondary model is
+// an attachment as opposed to something else
+// (akimbo).
+//
+float(float weapon) WepDef_WeaponSecondaryModelIsAttachment =
+{
+	switch(weapon) {
+		case W_KAR_SCOPE:
+		case W_HEADCRACKER:
+		case W_BK:
+		case W_KRAUS:
+			return true;
+		default:
+			return false;
+	}
+
+	return false;
+}


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Fixes several issues with Ballistic Knife functionality:
* Ballistic Knife now relinks after setting solid to `SOLID_TRIGGER` (fixes nzportable/nzp-team#1196)
* Ballistic Knife now updates second frame model in weapon attachment mode (fixes nzportable/nzp-team#1195)
* Ballistic Knife now properly applies damage when hitting a Zombies limbs.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
