### PR TITLE
GLOBAL: Add Lockdown gamemode

### DIFF
--- a/progs/ssqc.src
+++ b/progs/ssqc.src
@@ -86,6 +86,7 @@ gamemodes/hardcore.qc
 gamemodes/wild_west.qc
 gamemodes/sticks_and_stones.qc
 gamemodes/festive.qc
+gamemodes/lockdown.qc
 gamemodes/core.qc
 #ifdef QUAKEC_TEST
 tests/test_math.qc

--- a/source/client/main.qc
+++ b/source/client/main.qc
@@ -1397,7 +1397,7 @@ noref void() CSQC_Parse_Event =
 					break;
 				case GAMEMODE_LOCKDOWN:
 					chaptertitle = "LOCKDOWN";
-					location = "Don't open the damn door!";
+					location = "";
 					date = "";
 					person = "";
 					break;

--- a/source/client/main.qc
+++ b/source/client/main.qc
@@ -1395,6 +1395,12 @@ noref void() CSQC_Parse_Event =
 					date = "";
 					person = "";
 					break;
+				case GAMEMODE_LOCKDOWN:
+					chaptertitle = "LOCKDOWN";
+					location = "Don't open the damn door!";
+					date = "";
+					person = "";
+					break;
 				default:
 					break;
 			}

--- a/source/menu/menu_gset.qc
+++ b/source/menu/menu_gset.qc
@@ -47,7 +47,7 @@ void() Menu_GameSettings_ApplyGameMode =
     float current_gamemode = cvar("sv_gamemode");
     current_gamemode += 1;
 
-    if (current_gamemode > 6)
+    if (current_gamemode > 7)
         current_gamemode = 0;
 
     cvar_set("sv_gamemode", ftos(current_gamemode));
@@ -115,6 +115,7 @@ void() Menu_GameSettings =
         case 4: gamemode_description = "Ole Fashioned stand-off between you and the Dead."; gamemode_string = "WILD WEST"; break;
         case 5: gamemode_description = "Knives-and-Nades only. Grenades Explode on Contact."; gamemode_string = "STICKS & STONES"; break;
         case 6: gamemode_description = "The cycle continues. Old meets new in this Cold War inspired mode!"; gamemode_string = "FEVER"; break;
+        case 7: gamemode_description = "No Escape. Survive as Long as Possible."; gamemode_string = "LOCKDOWN"; break;
         default: gamemode_description = "???"; break;
     }
     Menu_Button(1, "ge_mode", "GAME MODE", gamemode_description) ? Menu_GameSettings_ApplyGameMode() : 0;

--- a/source/menu/menu_gset.qc
+++ b/source/menu/menu_gset.qc
@@ -115,7 +115,7 @@ void() Menu_GameSettings =
         case 4: gamemode_description = "Ole Fashioned stand-off between you and the Dead."; gamemode_string = "WILD WEST"; break;
         case 5: gamemode_description = "Knives-and-Nades only. Grenades Explode on Contact."; gamemode_string = "STICKS & STONES"; break;
         case 6: gamemode_description = "The cycle continues. Old meets new in this Cold War inspired mode!"; gamemode_string = "FEVER"; break;
-        case 7: gamemode_description = "No Escape. Survive as Long as Possible."; gamemode_string = "LOCKDOWN"; break;
+        case 7: gamemode_description = "No Escape. Survive as long as possible in the Starting Area."; gamemode_string = "LOCKDOWN"; break;
         default: gamemode_description = "???"; break;
     }
     Menu_Button(1, "ge_mode", "GAME MODE", gamemode_description) ? Menu_GameSettings_ApplyGameMode() : 0;

--- a/source/menu/menu_loby.qc
+++ b/source/menu/menu_loby.qc
@@ -118,6 +118,7 @@ void() Menu_Lobby =
         case 4: gamemode = "WILD WEST"; break;
         case 5: gamemode = "STICKS & STONES"; break;
         case 6: gamemode = "FEVER"; break;
+        case 7: gamemode = "LOCKDOWN"; break;
         default: gamemode = "???"; break;
     }
 

--- a/source/server/defs/custom.qc
+++ b/source/server/defs/custom.qc
@@ -495,6 +495,7 @@ float game_modifier_powerup_free_perk;
 float game_modifier_powerup_free_perk_is_rare;
 float game_modifier_powerup_max_ammo;
 float game_modifier_powerup_weapon_upgrade;
+float game_modifier_powerup_random_weapon;
 float game_modifier_powerup_bonus_points;
 float game_modifier_powerup_toast_for_all;
 float game_modifier_perk_purchase_limit;

--- a/source/server/entities/powerups.qc
+++ b/source/server/entities/powerups.qc
@@ -103,6 +103,7 @@ string(string file) PU_ResolveVOPath =
 		case GAMEMODE_STICKSNSTONES: path = strcat("sounds/modes/sticks/", file); break;
 		case GAMEMODE_WILDWEST: path = strcat("sounds/modes/wildwest/", file); break;
 		case GAMEMODE_FESTIVE: path = strcat("sounds/modes/festive/", file); break;
+		case GAMEMODE_LOCKDOWN: path = strcat("sounds/modes/lockdown/", file); break;
 		default: path = strcat("sounds/pu/", file); break;
 	}
 
@@ -589,6 +590,15 @@ float() PU_BonusPointsRequirement =
 }
 
 //
+// PU_RandomWeaponRequirement()
+// Requirements for Random Weapon Power-Up
+//
+float() PU_RandomWeaponRequirement =
+{
+	return game_modifier_powerup_random_weapon;
+}
+
+//
 // PU_MaxAmmo()
 // Max Ammo Power-Up Function
 //
@@ -636,6 +646,50 @@ void() PU_MaxAmmo =
 		players = find(players, classname, "player");
 	}
 };
+
+//
+// PU_RandomWeapon()
+// Random Weapon Power-Up Function
+//
+void() PU_RandomWeapon =
+{
+	entity players = find(world, classname, "player");
+	while(players != world) {
+		float random_weapon_id = -1;
+		float valid_weapon_found = false;
+
+		while(!valid_weapon_found) {
+			random_weapon_id = rint(random() * 59);
+
+			// skip bad weapons
+			if (random_weapon_id == W_NOWEP || random_weapon_id == W_GRENADE 
+				|| random_weapon_id == W_BETTY || random_weapon_id == W_BOWIE
+				|| random_weapon_id == W_RESERVED || random_weapon_id == W_RESERVED2)
+				continue;
+			
+			// skip if they already have this weapon or an equivalent
+			if (EqualNonPapWeapon(players.weapons[0].weapon_id) == EqualNonPapWeapon(random_weapon_id) ||
+				EqualNonPapWeapon(players.weapons[1].weapon_id) == EqualNonPapWeapon(random_weapon_id) ||
+				EqualNonPapWeapon(players.weapons[2].weapon_id) == EqualNonPapWeapon(random_weapon_id))
+				continue;
+
+			
+			valid_weapon_found = true;
+		}
+
+		// assign and sweap weapon
+		entity old_self = self;
+		self = players;
+		W_SprintStop();
+		W_AimOut();
+		Weapon_GiveWeapon(EqualNonPapWeapon(random_weapon_id), 0, 0, 0);
+		Weapon_AssignWeapon(0, EqualNonPapWeapon(random_weapon_id), 0, 0, 0);
+		Weapon_SwapWeapons(true);
+		self = old_self;
+
+		players = find(players, classname, "player");
+	}
+}
 
 //
 // PU_FreePerk()
@@ -781,6 +835,8 @@ void() PU_Init =
 					PU_UpgradeWeaponRequirement	);
 	PU_AddToStruct(PU_BONUSPOINTS,  "models/pu/points!.mdl",		"bonus_points.wav",		PU_BonusPoints,
 					PU_BonusPointsRequirement );
+	PU_AddToStruct(PU_RANDOMWEAPON,  "models/weapons/mp40/g_mp40.mdl",		"upgrade.wav",		PU_RandomWeapon,
+					PU_RandomWeaponRequirement );
 
 	// Nuke requires an extra Precache
 	precache_sound("sounds/pu/nuke.wav");

--- a/source/server/entities/powerups.qc
+++ b/source/server/entities/powerups.qc
@@ -835,7 +835,7 @@ void() PU_Init =
 					PU_UpgradeWeaponRequirement	);
 	PU_AddToStruct(PU_BONUSPOINTS,  "models/pu/points!.mdl",		"bonus_points.wav",		PU_BonusPoints,
 					PU_BonusPointsRequirement );
-	PU_AddToStruct(PU_RANDOMWEAPON,  "models/weapons/mp40/g_mp40.mdl",		"upgrade.wav",		PU_RandomWeapon,
+	PU_AddToStruct(PU_RANDOMWEAPON,  "models/weapons/mp40/g_mp40.mdl",		"random_weapon.wav",		PU_RandomWeapon,
 					PU_RandomWeaponRequirement );
 
 	// Nuke requires an extra Precache

--- a/source/server/gamemodes/core.qc
+++ b/source/server/gamemodes/core.qc
@@ -65,6 +65,7 @@ void() Gamemode_Init =
         case GAMEMODE_STICKSNSTONES: Gamemode_Sticks_Init(); break;
         case GAMEMODE_WILDWEST: Gamemode_WW_Init(); break;
         case GAMEMODE_FESTIVE: Gamemode_Festive_Init(); break;
+        case GAMEMODE_LOCKDOWN: Gamemode_Lockdown_Init(); break;
         default: error("Received unrecognized gamemode."); break;
     }
 };
@@ -83,6 +84,7 @@ void() Gamemode_Frame =
         case GAMEMODE_STICKSNSTONES: Gamemode_Sticks_Frame(); break;
         case GAMEMODE_WILDWEST: Gamemode_WW_Frame(); break;
         case GAMEMODE_FESTIVE: Gamemode_Festive_Frame(); break;
+        case GAMEMODE_LOCKDOWN: Gamemode_Lockdown_Frame(); break;
         default: error("Received unrecognized gamemode."); break;
     }
 
@@ -111,6 +113,7 @@ void() Gamemode_PlayerSpawn =
         case GAMEMODE_STICKSNSTONES: Gamemode_Sticks_PlayerSpawn(); break;
         case GAMEMODE_WILDWEST: Gamemode_WW_PlayerSpawn(); break;
         case GAMEMODE_FESTIVE: Gamemode_Festive_PlayerSpawn(); break;
+        case GAMEMODE_LOCKDOWN: Gamemode_Lockdown_PlayerSpawn(); break;
         default: error("Received unrecognized gamemode."); break;
     }
 };

--- a/source/server/gamemodes/lockdown.qc
+++ b/source/server/gamemodes/lockdown.qc
@@ -81,7 +81,7 @@ void() Gamemode_Lockdown_Frame =
     // Losing voiceline
     if ((find(world, classname, "gameover_watcher")) && lock_ran_endgame == false) {
         lock_ran_endgame = true;
-        Sound_PlaySound(world, "sounds/modes/lockdown/intro.wav", SOUND_TYPE_ENV_VOICE, SOUND_PRIORITY_PLAYALWAYS);
+        Sound_PlaySound(world, "sounds/modes/lockdown/lose.wav", SOUND_TYPE_ENV_VOICE, SOUND_PRIORITY_PLAYALWAYS);
     }
 };
 

--- a/source/server/gamemodes/lockdown.qc
+++ b/source/server/gamemodes/lockdown.qc
@@ -32,18 +32,18 @@ entity lock_perks[32];
 vector lock_positions[32];
 vector lock_angs[32];
 
-float(float count, string cvar) Gamemode_Lockdown_CollectPerks =
+float(float count, string ent_classname) Gamemode_Lockdown_CollectPerks =
 {
     entity e;
 
-    e = find(world, classname, cvar);
+    e = find(world, classname, ent_classname);
     while (e != world) {
         lock_perks[count] = e;
         lock_positions[count] = e.origin;
         lock_angs[count] = e.angles;
         count = count + 1;
 
-        e = find(e, classname, cvar);
+        e = find(e, classname, ent_classname);
     }
 
     return count;
@@ -151,14 +151,6 @@ void() Gamemode_Lockdown_Init =
 
 	// precache audio
     precache_sound("sounds/modes/lockdown/intro.wav");
-    precache_sound("sounds/modes/lockdown/carpenter.wav");
-	precache_sound("sounds/modes/lockdown/double_points.wav");
-	precache_sound("sounds/modes/lockdown/free_perk.wav");
-	precache_sound("sounds/modes/lockdown/insta_kill.wav");
-	precache_sound("sounds/modes/lockdown/kaboom.wav");
-	precache_sound("sounds/modes/lockdown/maxammo.wav");
-	precache_sound("sounds/modes/lockdown/random_weapon.wav");
-	precache_sound("sounds/modes/lockdown/upgrade.wav");
     precache_sound("sounds/modes/lockdown/lose.wav");
 };
 
@@ -168,8 +160,6 @@ void() Gamemode_Lockdown_Frame =
     if (lock_ran_post_init_logic == false) {
         // Play intro voiceline
         Sound_PlaySound(world, "sounds/modes/lockdown/intro.wav", SOUND_TYPE_ENV_VOICE, SOUND_PRIORITY_PLAYALWAYS);
-        // Randomize perk locations
-        Gamemode_Lockdown_RandomizePerkLocations();
 
         lock_ran_post_init_logic = true;
     }

--- a/source/server/gamemodes/lockdown.qc
+++ b/source/server/gamemodes/lockdown.qc
@@ -1,0 +1,66 @@
+/*
+	server/gamemodes/lockdown.qc
+
+	Core Logic for Lockdown.
+
+	Copyright (C) 2021-2026 NZ:P Team
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+	See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to:
+
+		Free Software Foundation, Inc.
+		59 Temple Place - Suite 330
+		Boston, MA  02111-1307, USA
+
+*/
+
+void() Gamemode_Lockdown_Init =
+{
+    // enable the free perk and weapon upgrade drops
+    game_modifier_powerup_free_perk = true;
+    game_modifier_powerup_weapon_upgrade = true;
+
+	// precache laugh
+	precache_sound("sounds/modes/lockdown/laugh.wav");
+};
+
+void() Gamemode_Lockdown_Frame =
+{
+    // Disable Doors
+    entity doors = find(world, classname, "door_nzp");
+    while(doors != world) {
+        doors.use = SUB_Null;
+        doors.touch = SUB_Null;
+
+        if (doors.trigger_field != world)
+            remove(doors.trigger_field);
+
+        doors = find(doors, classname, "door_nzp");
+    }
+    doors = find(world, classname, "door_nzp_cost");
+    while(doors != world) {
+        doors.use = SUB_Null;
+        doors.touch = SUB_Null;
+
+        if (doors.trigger_field != world)
+            remove(doors.trigger_field);
+
+        doors = find(doors, classname, "door_nzp_cost");
+    }
+};
+
+void() Gamemode_Lockdown_PlayerSpawn =
+{
+    return;
+};

--- a/source/server/gamemodes/lockdown.qc
+++ b/source/server/gamemodes/lockdown.qc
@@ -28,99 +28,44 @@
 float lock_ran_post_init_logic;
 float lock_ran_endgame;
 float lock_last_perk_shuffle_round;
+entity lock_perks[32];
+vector lock_positions[32];
+vector lock_angs[32];
+
+float(float count, string cvar) Gamemode_Lockdown_CollectPerks =
+{
+    entity e;
+
+    e = find(world, classname, cvar);
+    while (e != world) {
+        lock_perks[count] = e;
+        lock_positions[count] = e.origin;
+        lock_angs[count] = e.angles;
+        count = count + 1;
+
+        e = find(e, classname, cvar);
+    }
+
+    return count;
+};
 
 void() Gamemode_Lockdown_RandomizePerkLocations =
 {
-    entity perks[32];
-    vector positions[32];
-    vector angs[32];
-
     float count;
     count = 0;
 
     entity e;
 
     // Collect all perk machines
-    e = find(world, classname, "perk_revive");
-    while (e != world) {
-        perks[count] = e;
-        positions[count] = e.origin;
-        angs[count] = e.angles;
-        count = count + 1;
-        e = find(e, classname, "perk_revive");
-    }
-
-    e = find(world, classname, "perk_juggernog");
-    while (e != world) {
-        perks[count] = e;
-        positions[count] = e.origin;
-        angs[count] = e.angles;
-        count = count + 1;
-        e = find(e, classname, "perk_juggernog");
-    }
-
-    e = find(world, classname, "perk_speed");
-    while (e != world) {
-        perks[count] = e;
-        positions[count] = e.origin;
-        angs[count] = e.angles;
-        count = count + 1;
-        e = find(e, classname, "perk_speed");
-    }
-
-    e = find(world, classname, "perk_double");
-    while (e != world) {
-        perks[count] = e;
-        positions[count] = e.origin;
-        angs[count] = e.angles;
-        count = count + 1;
-        e = find(e, classname, "perk_double");
-    }
-
-    e = find(world, classname, "perk_flopper");
-    while (e != world) {
-        perks[count] = e;
-        positions[count] = e.origin;
-        angs[count] = e.angles;
-        count = count + 1;
-        e = find(e, classname, "perk_flopper");
-    }
-
-    e = find(world, classname, "perk_staminup");
-    while (e != world) {
-        perks[count] = e;
-        positions[count] = e.origin;
-        angs[count] = e.angles;
-        count = count + 1;
-        e = find(e, classname, "perk_staminup");
-    }
-
-    e = find(world, classname, "perk_deadshot");
-    while (e != world) {
-        perks[count] = e;
-        positions[count] = e.origin;
-        angs[count] = e.angles;
-        count = count + 1;
-        e = find(e, classname, "perk_deadshot");
-    }
-
-    e = find(world, classname, "perk_mule");
-    while (e != world) {
-        perks[count] = e;
-        positions[count] = e.origin;
-        angs[count] = e.angles;
-        count = count + 1;
-        e = find(e, classname, "perk_mule");
-    }
-
-    e = find(world, classname, "perk_pap");
-    while (e != world) {
-        perks[count] = e;
-        positions[count] = e.origin;
-        angs[count] = e.angles;
-        count = count + 1;
-        e = find(e, classname, "perk_pap");
-    }
+    count = Gamemode_Lockdown_CollectPerks(count, "perk_revive");
+    count = Gamemode_Lockdown_CollectPerks(count, "perk_juggernog");
+    count = Gamemode_Lockdown_CollectPerks(count, "perk_speed");
+    count = Gamemode_Lockdown_CollectPerks(count, "perk_double");
+    count = Gamemode_Lockdown_CollectPerks(count, "perk_flopper");
+    count = Gamemode_Lockdown_CollectPerks(count, "perk_staminup");
+    count = Gamemode_Lockdown_CollectPerks(count, "perk_deadshot");
+    count = Gamemode_Lockdown_CollectPerks(count, "perk_mule");
+    count = Gamemode_Lockdown_CollectPerks(count, "perk_pap");
 
     // Shuffle positions of all perks
     float i;
@@ -129,22 +74,22 @@ void() Gamemode_Lockdown_RandomizePerkLocations =
         j = floor(random() * (i + 1));
 
         vector tmp_v;
-        tmp_v = positions[i];
-        positions[i] = positions[j];
-        positions[j] = tmp_v;
+        tmp_v = lock_positions[i];
+        lock_positions[i] = lock_positions[j];
+        lock_positions[j] = tmp_v;
 
-        tmp_v = angs[i];
-        angs[i] = angs[j];
-        angs[j] = tmp_v;
+        tmp_v = lock_angs[i];
+        lock_angs[i] = lock_angs[j];
+        lock_angs[j] = tmp_v;
     }
 
     // Apply shuffled positions
     for (i = 0; i < count; i = i + 1) {
         entity p;
-        p = perks[i];
+        p = lock_perks[i];
 
-        setorigin(p, positions[i]);
-        p.angles = angs[i];
+        setorigin(p, lock_positions[i]);
+        p.angles = lock_angs[i];
         p.oldorigin = p.origin;
 
         // Fix Pack-a-Punch attachments or they'll
@@ -191,9 +136,9 @@ void() Gamemode_Lockdown_RandomizePerkLocations =
             p.box2 = tempv;
         }
 
-        setorigin(perks[i], positions[i]);
-        perks[i].angles = angs[i];
-        perks[i].oldorigin = perks[i].origin;
+        setorigin(lock_perks[i], lock_positions[i]);
+        lock_perks[i].angles = lock_angs[i];
+        lock_perks[i].oldorigin = lock_perks[i].origin;
     }
 }
 

--- a/source/server/gamemodes/lockdown.qc
+++ b/source/server/gamemodes/lockdown.qc
@@ -27,6 +27,7 @@
 
 float lock_ran_post_init_logic;
 float lock_ran_endgame;
+float lock_last_perk_shuffle_round;
 
 void() Gamemode_Lockdown_RandomizePerkLocations =
 {
@@ -226,6 +227,21 @@ void() Gamemode_Lockdown_Frame =
         Gamemode_Lockdown_RandomizePerkLocations();
 
         lock_ran_post_init_logic = true;
+    }
+    
+    // Every 5 rounds, reroll the perks to help the player
+    // progress in the game
+    if (floor(rounds / 5) * 5 == rounds) {
+        // Prevents the perks from shuffling all round
+        if (rounds != lock_last_perk_shuffle_round) {
+            lock_last_perk_shuffle_round = rounds;
+
+            // Avoid running on round 0 & round 1 since we run on
+            // game start anyways
+            if (rounds > 0 && rounds != 1) {
+                Gamemode_Lockdown_RandomizePerkLocations();
+            }
+        }
     }
 
     // Disable Doors

--- a/source/server/gamemodes/lockdown.qc
+++ b/source/server/gamemodes/lockdown.qc
@@ -30,6 +30,7 @@ void() Gamemode_Lockdown_Init =
     // enable the free perk and weapon upgrade drops
     game_modifier_powerup_free_perk = true;
     game_modifier_powerup_weapon_upgrade = true;
+    game_modifier_powerup_random_weapon = true;
 
 	// precache laugh
 	precache_sound("sounds/modes/lockdown/laugh.wav");

--- a/source/server/gamemodes/lockdown.qc
+++ b/source/server/gamemodes/lockdown.qc
@@ -139,6 +139,57 @@ void() Gamemode_Lockdown_RandomizePerkLocations =
 
     // Apply shuffled positions
     for (i = 0; i < count; i = i + 1) {
+        entity p;
+        p = perks[i];
+
+        setorigin(p, positions[i]);
+        p.angles = angs[i];
+        p.oldorigin = p.origin;
+
+        // Fix Pack-a-Punch attachments or they'll
+        // float in their old locations (which is obviously incorrect!)
+        if (p.classname == "perk_pap") {
+            makevectors(p.angles);
+
+            vector newpos;
+
+            // Move roller
+            if (p.active_door) {
+                entity roller;
+                roller = p.active_door;
+
+                newpos = p.origin;
+                newpos = newpos + v_right * p.box1_y;
+                newpos = newpos + v_forward * p.box1_x;
+                newpos = newpos + v_up * p.box1_z;
+
+                setorigin(roller, newpos);
+                roller.angles = p.angles;
+            }
+
+            // Move flag
+            if (p.boxweapon) {
+                entity flag;
+                flag = p.boxweapon;
+
+                newpos = p.origin;
+                newpos = newpos + v_right * p.box3_y;
+                newpos = newpos + v_forward * p.box3_x;
+                newpos = newpos + v_up * p.box3_z;
+
+                setorigin(flag, newpos);
+                flag.angles = p.angles;
+            }
+
+            // Recalculate spark offset
+            vector tempv;
+            tempv = p.origin;
+            tempv = tempv + v_right * p.box2_y;
+            tempv = tempv + v_forward * p.box2_x;
+            tempv = tempv + v_up * p.box2_z;
+            p.box2 = tempv;
+        }
+
         setorigin(perks[i], positions[i]);
         perks[i].angles = angs[i];
         perks[i].oldorigin = perks[i].origin;

--- a/source/server/gamemodes/lockdown.qc
+++ b/source/server/gamemodes/lockdown.qc
@@ -28,6 +28,123 @@
 float lock_ran_post_init_logic;
 float lock_ran_endgame;
 
+void() Gamemode_Lockdown_RandomizePerkLocations =
+{
+    entity perks[32];
+    vector positions[32];
+    vector angs[32];
+
+    float count;
+    count = 0;
+
+    entity e;
+
+    // Collect all perk machines
+    e = find(world, classname, "perk_revive");
+    while (e != world) {
+        perks[count] = e;
+        positions[count] = e.origin;
+        angs[count] = e.angles;
+        count = count + 1;
+        e = find(e, classname, "perk_revive");
+    }
+
+    e = find(world, classname, "perk_juggernog");
+    while (e != world) {
+        perks[count] = e;
+        positions[count] = e.origin;
+        angs[count] = e.angles;
+        count = count + 1;
+        e = find(e, classname, "perk_juggernog");
+    }
+
+    e = find(world, classname, "perk_speed");
+    while (e != world) {
+        perks[count] = e;
+        positions[count] = e.origin;
+        angs[count] = e.angles;
+        count = count + 1;
+        e = find(e, classname, "perk_speed");
+    }
+
+    e = find(world, classname, "perk_double");
+    while (e != world) {
+        perks[count] = e;
+        positions[count] = e.origin;
+        angs[count] = e.angles;
+        count = count + 1;
+        e = find(e, classname, "perk_double");
+    }
+
+    e = find(world, classname, "perk_flopper");
+    while (e != world) {
+        perks[count] = e;
+        positions[count] = e.origin;
+        angs[count] = e.angles;
+        count = count + 1;
+        e = find(e, classname, "perk_flopper");
+    }
+
+    e = find(world, classname, "perk_staminup");
+    while (e != world) {
+        perks[count] = e;
+        positions[count] = e.origin;
+        angs[count] = e.angles;
+        count = count + 1;
+        e = find(e, classname, "perk_staminup");
+    }
+
+    e = find(world, classname, "perk_deadshot");
+    while (e != world) {
+        perks[count] = e;
+        positions[count] = e.origin;
+        angs[count] = e.angles;
+        count = count + 1;
+        e = find(e, classname, "perk_deadshot");
+    }
+
+    e = find(world, classname, "perk_mule");
+    while (e != world) {
+        perks[count] = e;
+        positions[count] = e.origin;
+        angs[count] = e.angles;
+        count = count + 1;
+        e = find(e, classname, "perk_mule");
+    }
+
+    e = find(world, classname, "perk_pap");
+    while (e != world) {
+        perks[count] = e;
+        positions[count] = e.origin;
+        angs[count] = e.angles;
+        count = count + 1;
+        e = find(e, classname, "perk_pap");
+    }
+
+    // Shuffle positions of all perks
+    float i;
+    for (i = count - 1; i > 0; i = i - 1) {
+        float j;
+        j = floor(random() * (i + 1));
+
+        vector tmp_v;
+        tmp_v = positions[i];
+        positions[i] = positions[j];
+        positions[j] = tmp_v;
+
+        tmp_v = angs[i];
+        angs[i] = angs[j];
+        angs[j] = tmp_v;
+    }
+
+    // Apply shuffled positions
+    for (i = 0; i < count; i = i + 1) {
+        setorigin(perks[i], positions[i]);
+        perks[i].angles = angs[i];
+        perks[i].oldorigin = perks[i].origin;
+    }
+}
+
 void() Gamemode_Lockdown_Init =
 {
     // enable the free perk and weapon upgrade drops
@@ -52,7 +169,11 @@ void() Gamemode_Lockdown_Frame =
 {
     // Intro voiceline
     if (lock_ran_post_init_logic == false) {
+        // Play intro voiceline
         Sound_PlaySound(world, "sounds/modes/lockdown/intro.wav", SOUND_TYPE_ENV_VOICE, SOUND_PRIORITY_PLAYALWAYS);
+        // Randomize perk locations
+        Gamemode_Lockdown_RandomizePerkLocations();
+
         lock_ran_post_init_logic = true;
     }
 

--- a/source/server/gamemodes/lockdown.qc
+++ b/source/server/gamemodes/lockdown.qc
@@ -25,6 +25,9 @@
 
 */
 
+float lock_ran_post_init_logic;
+float lock_ran_endgame;
+
 void() Gamemode_Lockdown_Init =
 {
     // enable the free perk and weapon upgrade drops
@@ -32,12 +35,27 @@ void() Gamemode_Lockdown_Init =
     game_modifier_powerup_weapon_upgrade = true;
     game_modifier_powerup_random_weapon = true;
 
-	// precache laugh
-	precache_sound("sounds/modes/lockdown/laugh.wav");
+	// precache audio
+    precache_sound("sounds/modes/lockdown/intro.wav");
+    precache_sound("sounds/modes/lockdown/carpenter.wav");
+	precache_sound("sounds/modes/lockdown/double_points.wav");
+	precache_sound("sounds/modes/lockdown/free_perk.wav");
+	precache_sound("sounds/modes/lockdown/insta_kill.wav");
+	precache_sound("sounds/modes/lockdown/kaboom.wav");
+	precache_sound("sounds/modes/lockdown/maxammo.wav");
+	precache_sound("sounds/modes/lockdown/random_weapon.wav");
+	precache_sound("sounds/modes/lockdown/upgrade.wav");
+    precache_sound("sounds/modes/lockdown/lose.wav");
 };
 
 void() Gamemode_Lockdown_Frame =
 {
+    // Intro voiceline
+    if (lock_ran_post_init_logic == false) {
+        Sound_PlaySound(world, "sounds/modes/lockdown/intro.wav", SOUND_TYPE_ENV_VOICE, SOUND_PRIORITY_PLAYALWAYS);
+        lock_ran_post_init_logic = true;
+    }
+
     // Disable Doors
     entity doors = find(world, classname, "door_nzp");
     while(doors != world) {
@@ -58,6 +76,12 @@ void() Gamemode_Lockdown_Frame =
             remove(doors.trigger_field);
 
         doors = find(doors, classname, "door_nzp_cost");
+    }
+
+    // Losing voiceline
+    if ((find(world, classname, "gameover_watcher")) && lock_ran_endgame == false) {
+        lock_ran_endgame = true;
+        Sound_PlaySound(world, "sounds/modes/lockdown/intro.wav", SOUND_TYPE_ENV_VOICE, SOUND_PRIORITY_PLAYALWAYS);
     }
 };
 

--- a/source/server/main.qc
+++ b/source/server/main.qc
@@ -435,6 +435,7 @@ void() worldspawn =
 	game_modifier_powerup_free_perk = false;
 	game_modifier_powerup_max_ammo = true;
 	game_modifier_powerup_weapon_upgrade = false;
+	game_modifier_powerup_random_weapon = false;
 	game_modifier_powerup_bonus_points = false;
 	game_modifier_powerup_toast_for_all = false;
 	game_modifier_can_packapunch = true;

--- a/source/shared/shared_defs.qc
+++ b/source/shared/shared_defs.qc
@@ -357,6 +357,7 @@ float 	map_compatibility_mode;
 #define GAMEMODE_WILDWEST       4
 #define GAMEMODE_STICKSNSTONES  5
 #define GAMEMODE_FESTIVE 		6
+#define GAMEMODE_LOCKDOWN		7
 
 // Misc. player statistics
 .float playernum;

--- a/source/shared/shared_defs.qc
+++ b/source/shared/shared_defs.qc
@@ -156,6 +156,7 @@ float 	map_compatibility_mode;
 #define PU_FREEPERK			5
 #define PU_UPGRADEWEAPON	6
 #define PU_BONUSPOINTS		7
+#define PU_RANDOMWEAPON		8
 
 // Weapon Firetype definitions
 #define FIRETYPE_FULLAUTO	0


### PR DESCRIPTION
### Description of Changes
---
This PR adds the Lockdown, which is essentially the "one-room challenge". This mode adds a new random weapon powerup, which grants a random weapon once picked up.

Every 5 rounds, the perks & pack-a-punch will randomize locations.

### Visual Sample
---
Random weapon powerup:

https://github.com/user-attachments/assets/116636d6-c066-4e86-8019-12e426384132

Perks randomizing:


https://github.com/user-attachments/assets/5229432b-5d94-400d-aa46-334b42dc07ce

(Apologies for lag in the beginning of this video)

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
