### PR TITLE
SERVER: Fixes for Vril gamemode support

### DIFF
--- a/source/server/defs/standard.qc
+++ b/source/server/defs/standard.qc
@@ -269,7 +269,7 @@ string(float num)                                                               
 string  (string s)                                                                              strtolower          = #480;
 float   (float caseinsensitive, string s)                                                       crc16               = #494;
 void    (string trackname)                                                                    	songegg             = #500;
-void    ()                                                                                   	nzp_poweruptoast         = #501;
+void    ()                                                                                   	nzp_poweruptoast    = #501;
 void    (entity who)                                                                            grenade_pulse       = #502;
 float   ()                                                                                      nzp_maxai           = #503;
 void    (entity who)                                                                            nzp_bettyprompt     = #504;
@@ -279,6 +279,9 @@ void    (entity who, float color, float duration, float type)                   
 void    (entity who, float state)                                                               nzp_lockviewmodel   = #508;
 void    (entity who, float low_frequency, float high_frequency, float duration)                 nzp_rumble          = #509;
 void    (float gamemode)                                                                        nzp_setclientmode   = #510;
+void    (vector color)                                                                          nzp_setroundcolor   = #511;
+float   ()                                                                                      nzp_getmonthofyear  = #512;
+void    (float orientation)                                                                     nzp_setperkorientation = #513;
 
 //
 // constants

--- a/source/server/gamemodes/festive.qc
+++ b/source/server/gamemodes/festive.qc
@@ -31,6 +31,7 @@ string festive_round_color;
 
 void() Gamemode_Festive_Init =
 {
+    precache_model(GetWeaponModel(W_BOWIE, false));
     precache_sound("sounds/modes/festive/rnd_splash.wav");
     precache_sound("sounds/modes/festive/rnd_start.wav");
     precache_sound("sounds/modes/festive/rnd_end.wav");
@@ -183,19 +184,24 @@ void() Gamemode_Festive_PlayerSpawn =
     nzp_setdoubletapver(self, false);
 
     // Give the player a random starting weapon
-    float weapon_options[6] = {W_COLT, W_KAR, W_M1A1, W_SAWNOFF, W_MP40, W_GEWEHR};
     float weapon_chance = random();
+    float selected_weapon = W_COLT;
 
-    for (float i = 0; i < 6; i++) {
-        if (weapon_chance < (1/(i + 1))) {
-            Weapon_AssignWeapon(0, weapon_options[i], 0, 0, 0);
-        }
-    }
+    if (weapon_chance < (1.0 / 6.0))
+        selected_weapon = W_GEWEHR;
+    else if (weapon_chance < (1.0 / 5.0))
+        selected_weapon = W_MP40;
+    else if (weapon_chance < (1.0 / 4.0))
+        selected_weapon = W_SAWNOFF;
+    else if (weapon_chance < (1.0 / 3.0))
+        selected_weapon = W_M1A1;
+    else if (weapon_chance < (1.0 / 2.0))
+        selected_weapon = W_KAR;
 
-#ifdef FTE
+    Weapon_AssignWeapon(0, selected_weapon, 0, 0, 0);
+
     nzp_setroundcolor(stov(festive_round_color));
     nzp_setperkorientation(HUD_PERK_ORI_CW);
-#endif // FTE
 };
 
 float(float current_earned_score, float damage_style) Gamemode_Festive_ScoreForDamage =

--- a/source/server/main.qc
+++ b/source/server/main.qc
@@ -413,8 +413,6 @@ void() worldspawn =
 
 	current_month_of_year = nzp_getmonthofyear();
 
-#endif // FTE
-
 	mappath = strcat("maps/", mapname);
 	mappath = strzone(mappath);
 

--- a/source/server/main.qc
+++ b/source/server/main.qc
@@ -409,6 +409,8 @@ void() worldspawn =
 
 	autocvar(sv_spoofmonth, 0);
 
+#endif // FTE
+
 	current_month_of_year = nzp_getmonthofyear();
 
 #endif // FTE

--- a/source/shared/weapon_stats.qc
+++ b/source/shared/weapon_stats.qc
@@ -235,6 +235,7 @@ string(float wep, float weapon_tier) GetWeaponName =
 			weapon_name = strcat(weapon_name, " (Tier ");
 			weapon_name = strcat(weapon_name, tier_numeral);
 			weapon_name = strcat(weapon_name, ")");
+			weapon_name = strzone(weapon_name);
 		}
 	}
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Minor QC changes to enable some game mode functionality on Vril.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
