### PR TITLE
SERVER: Workaround local array bugs to boot Gun Game on Vril

### DIFF
--- a/source/server/defs/standard.qc
+++ b/source/server/defs/standard.qc
@@ -99,6 +99,8 @@ void            end_sys_globals;						// flag for structure dumping
 .float          grenades;
 .float          perks;									// bit flags
 .float          takedamage;
+.float          gungame_weapon_idx;
+.float          gungame_score_threshold;
 .entity         chain;
 .float          deadflag;
 .vector         view_ofs;								// add to origin to get eye point

--- a/source/server/gamemodes/gun_game.qc
+++ b/source/server/gamemodes/gun_game.qc
@@ -140,10 +140,12 @@ void() Gamemode_GunGame_Frame =
         gungame_ran_post_init_logic = true;
     }
 
-    // Make sure the Player never runs out of ammo.
-    entity players = find(world, classname, "player");
-    while(players != world) {
-        players.weapons[0].weapon_reserve = getWeaponAmmo(players.weapons[0].weapon_id);
+	// Make sure the Player never runs out of ammo.
+	entity players = find(world, classname, "player");
+	while(players != world) {
+		float weapon_id = players.weapons[0].weapon_id;
+		float weapon_ammo = getWeaponAmmo(weapon_id);
+		players.weapons[0].weapon_reserve = weapon_ammo;
 
         if (players.gungame_update_time < time) {
             entity old_self = self;
@@ -172,26 +174,7 @@ void() Gamemode_GunGame_PlayerSpawn =
 
 void() Gamemode_GunGame_PlayerPostThink =
 {
-#ifndef FTE
-    string next_weapon = "";
 
-    if (self.gungame_weapon_idx + 1 == GUNGAME_MAX_WEAPONS) {
-        next_weapon = "WIN";
-    } else {
-        next_weapon = GetWeaponName(gungame_weapon_pool[self.gungame_weapon_idx + 1], -1);
-    }
-
-    string centerprint_text = "";
-    centerprint_text = strcat("[", ftos(self.gungame_weapon_idx + 1));
-    centerprint_text = strcat(centerprint_text, "/32]: ");
-    centerprint_text = strcat(centerprint_text, GetWeaponName(gungame_weapon_pool[self.gungame_weapon_idx], -1));
-    centerprint_text = strcat(centerprint_text, "\nNeed [");
-    centerprint_text = strcat(centerprint_text, ftos(self.gungame_score_threshold - self.score));
-    centerprint_text = strcat(centerprint_text, "] More Score to Advance\nNext Weapon: ");
-    centerprint_text = strcat(centerprint_text, next_weapon);
-
-    centerprint(self, centerprint_text);
-#endif // FTE
 };
 
 void(entity who) Gamemode_GunGame_AdvertiseAdvancement =
@@ -200,7 +183,7 @@ void(entity who) Gamemode_GunGame_AdvertiseAdvancement =
 	FTE_BroadcastMessage(world, CSQC_BROADCAST_GUNGAMEADVANCEMENT, 2, who.playernum);
 #else
     bprint(PRINT_HIGH, who.netname);
-    bprint(PRINT_HIGH, "ADVANCED!\n");
+    bprint(PRINT_HIGH, " reached a new tier!\n");
 #endif // FTE
 
     Sound_PlaySound(world, "sounds/pu/pickup.wav", SOUND_TYPE_ENV_OBJECT, SOUND_PRIORITY_PLAYALWAYS);
@@ -334,7 +317,7 @@ void(float score_earned) Gamemode_GunGame_PlayerAddScore =
             FTE_BroadcastMessage(world, CSQC_BROADCAST_GUNGAMEWINNER, 2, self.playernum);
         #else
             bprint(PRINT_HIGH, self.netname);
-            bprint(PRINT_HIGH, "can Activate the Nuke!\n");
+            bprint(PRINT_HIGH, " can Activate the Nuke!\n");
         #endif // FTE
 
             Gamemode_GunGame_SpawnNuke();

--- a/source/server/main.qc
+++ b/source/server/main.qc
@@ -34,8 +34,10 @@ void() Gamemode_Frame;
 void() SUB_Remove = {remove(self);}
 string(string current_tune) Gamemode_GetSplashTune;
 
+#ifdef FTE
 .float gungame_weapon_idx;
 .float gungame_score_threshold;
+#endif
 
 //called when starting server/loading the map
 void() main =

--- a/source/server/utilities/weapon_utilities.qc
+++ b/source/server/utilities/weapon_utilities.qc
@@ -51,6 +51,9 @@ void() W_AimOut;
 void() ReturnWeaponModel;
 void(entity person) W_HideCrosshair;
 
+guninventory_struct weapon_swap_storage[MAX_PLAYER_WEAPONS];
+guninventory_struct weapon_fixup_storage[MAX_PLAYER_WEAPONS];
+
 //
 // Weapon_GetPlayerAmmoInSlot(person, slot)
 // Returns the reserve ammo the player has in a weapon slot.
@@ -224,42 +227,43 @@ void Weapon_SwapWeapons(float play_animation)
 	// Fix fire rate exploit
 	self.reload_delay2 = self.fire_delay2 = self.reload_delay = self.fire_delay = true;
 
-	// Store current weapons locally
-	guninventory_struct weapons_storage[MAX_PLAYER_WEAPONS];
+	// Store current weapons in non-local scratch space.
+	for(float i = 0; i < MAX_PLAYER_WEAPONS; i++)
+		weapon_swap_storage[i].weapon_id = 0;
+
 	for(float i = 0; i < MAX_PLAYER_WEAPONS; i++) {
 		if (self.weapons[i].weapon_id != 0) {
 			weapon_count++;
-			weapons_storage[i].weapon_id = self.weapons[i].weapon_id;
-			weapons_storage[i].weapon_magazine = self.weapons[i].weapon_magazine;
-			weapons_storage[i].weapon_magazine_left = self.weapons[i].weapon_magazine_left;
-			weapons_storage[i].weapon_reserve = self.weapons[i].weapon_reserve;
-			weapons_storage[i].weapon_skin = self.weapons[i].weapon_skin;
-			weapons_storage[i].weapon_tier = self.weapons[i].weapon_tier;
-			weapons_storage[i].is_mulekick_weapon = self.weapons[i].is_mulekick_weapon;
+			weapon_swap_storage[i].weapon_id = self.weapons[i].weapon_id;
+			weapon_swap_storage[i].weapon_magazine = self.weapons[i].weapon_magazine;
+			weapon_swap_storage[i].weapon_magazine_left = self.weapons[i].weapon_magazine_left;
+			weapon_swap_storage[i].weapon_reserve = self.weapons[i].weapon_reserve;
+			weapon_swap_storage[i].weapon_skin = self.weapons[i].weapon_skin;
+			weapon_swap_storage[i].weapon_tier = self.weapons[i].weapon_tier;
+			weapon_swap_storage[i].is_mulekick_weapon = self.weapons[i].is_mulekick_weapon;
 		}
 	}
 
 	// Iterate over the player inventory and shift the array around!
 	for(float j = 0; j < weapon_count; j++) {
 		if (j != weapon_count - 1) {
-			self.weapons[j + 1].weapon_id = weapons_storage[j].weapon_id;
-			self.weapons[j + 1].weapon_magazine = weapons_storage[j].weapon_magazine;
-			self.weapons[j + 1].weapon_magazine_left = weapons_storage[j].weapon_magazine_left;
-			self.weapons[j + 1].weapon_reserve = weapons_storage[j].weapon_reserve;
-			self.weapons[j + 1].weapon_skin = weapons_storage[j].weapon_skin;
-			self.weapons[j + 1].weapon_tier = weapons_storage[j].weapon_tier;
-			self.weapons[j + 1].is_mulekick_weapon = weapons_storage[j].is_mulekick_weapon;
-		} else {
-		 	self.weapons[0].weapon_id = weapons_storage[j].weapon_id;
-			self.weapons[0].weapon_magazine = weapons_storage[j].weapon_magazine;
-			self.weapons[0].weapon_magazine_left = weapons_storage[j].weapon_magazine_left;
-			self.weapons[0].weapon_reserve = weapons_storage[j].weapon_reserve;
-			self.weapons[0].weapon_skin = weapons_storage[j].weapon_skin;
-			self.weapons[0].weapon_tier = weapons_storage[j].weapon_tier;
-			self.weapons[0].is_mulekick_weapon = weapons_storage[j].is_mulekick_weapon;
+				self.weapons[j + 1].weapon_id = weapon_swap_storage[j].weapon_id;
+				self.weapons[j + 1].weapon_magazine = weapon_swap_storage[j].weapon_magazine;
+				self.weapons[j + 1].weapon_magazine_left = weapon_swap_storage[j].weapon_magazine_left;
+				self.weapons[j + 1].weapon_reserve = weapon_swap_storage[j].weapon_reserve;
+				self.weapons[j + 1].weapon_skin = weapon_swap_storage[j].weapon_skin;
+				self.weapons[j + 1].weapon_tier = weapon_swap_storage[j].weapon_tier;
+				self.weapons[j + 1].is_mulekick_weapon = weapon_swap_storage[j].is_mulekick_weapon;
+			} else {
+				self.weapons[0].weapon_id = weapon_swap_storage[j].weapon_id;
+				self.weapons[0].weapon_magazine = weapon_swap_storage[j].weapon_magazine;
+				self.weapons[0].weapon_magazine_left = weapon_swap_storage[j].weapon_magazine_left;
+				self.weapons[0].weapon_reserve = weapon_swap_storage[j].weapon_reserve;
+				self.weapons[0].weapon_skin = weapon_swap_storage[j].weapon_skin;
+				self.weapons[0].weapon_tier = weapon_swap_storage[j].weapon_tier;
+				self.weapons[0].is_mulekick_weapon = weapon_swap_storage[j].is_mulekick_weapon;
 		}
 	}
-
 	if (play_animation == true) {
 		// Properly update the weapon ID
 		self.weapon = self.weapons[0].weapon_id;
@@ -359,8 +363,11 @@ void Weapon_AssignWeapon(float weapon_slot, float weapon_id, float weapon_mag, f
 
 	if (weapon_reserve > 0)
 		self.weapons[weapon_slot].weapon_reserve = weapon_reserve;
-	else
-		self.weapons[weapon_slot].weapon_reserve = getWeaponAmmo(self.weapons[weapon_slot].weapon_id);
+	else {
+		float assigned_weapon_id = self.weapons[weapon_slot].weapon_id;
+		float assigned_weapon_ammo = getWeaponAmmo(assigned_weapon_id);
+		self.weapons[weapon_slot].weapon_reserve = assigned_weapon_ammo;
+	}
 
 	if (weapon_slot == MULEKICK_WEAPON_SLOT - 1 && Weapon_HasNoMulekickWeapon())
 		self.weapons[weapon_slot].is_mulekick_weapon = true;
@@ -416,17 +423,19 @@ void Weapon_GiveWeapon(float weapon_id, float weapon_mag, float weapon_reserve, 
 //
 void Weapon_FixUpList()
 {
-	// Store current weapons locally
-	guninventory_struct weapons_storage[MAX_PLAYER_WEAPONS];
+	// Store current weapons in non-local scratch space.
+	for(float i = 0; i < MAX_PLAYER_WEAPONS; i++)
+		weapon_fixup_storage[i].weapon_id = 0;
+
 	for(float i = 0; i < MAX_PLAYER_WEAPONS; i++) {
 		if (self.weapons[i].weapon_id != 0) {
-			weapons_storage[i].weapon_id = self.weapons[i].weapon_id;
-			weapons_storage[i].weapon_magazine = self.weapons[i].weapon_magazine;
-			weapons_storage[i].weapon_magazine_left = self.weapons[i].weapon_magazine_left;
-			weapons_storage[i].weapon_reserve = self.weapons[i].weapon_reserve;
-			weapons_storage[i].weapon_skin = self.weapons[i].weapon_skin;
-			weapons_storage[i].weapon_tier = self.weapons[i].weapon_tier;
-			weapons_storage[i].is_mulekick_weapon = self.weapons[i].is_mulekick_weapon;
+			weapon_fixup_storage[i].weapon_id = self.weapons[i].weapon_id;
+			weapon_fixup_storage[i].weapon_magazine = self.weapons[i].weapon_magazine;
+			weapon_fixup_storage[i].weapon_magazine_left = self.weapons[i].weapon_magazine_left;
+			weapon_fixup_storage[i].weapon_reserve = self.weapons[i].weapon_reserve;
+			weapon_fixup_storage[i].weapon_skin = self.weapons[i].weapon_skin;
+			weapon_fixup_storage[i].weapon_tier = self.weapons[i].weapon_tier;
+			weapon_fixup_storage[i].is_mulekick_weapon = self.weapons[i].is_mulekick_weapon;
 		}
 	}
 
@@ -443,14 +452,14 @@ void Weapon_FixUpList()
 
 	float weapon_index = 0;
 	for(float i = 0; i < MAX_PLAYER_WEAPONS; i++) {
-		if (weapons_storage[i].weapon_id != 0) {
-			self.weapons[weapon_index].weapon_id = weapons_storage[i].weapon_id;
-			self.weapons[weapon_index].weapon_magazine = weapons_storage[i].weapon_magazine;
-			self.weapons[weapon_index].weapon_magazine_left = weapons_storage[i].weapon_magazine_left;
-			self.weapons[weapon_index].weapon_reserve = weapons_storage[i].weapon_reserve;
-			self.weapons[weapon_index].weapon_skin = weapons_storage[i].weapon_skin;
-			self.weapons[weapon_index].weapon_tier = weapons_storage[i].weapon_tier;
-			self.weapons[weapon_index].is_mulekick_weapon = weapons_storage[i].is_mulekick_weapon;
+		if (weapon_fixup_storage[i].weapon_id != 0) {
+			self.weapons[weapon_index].weapon_id = weapon_fixup_storage[i].weapon_id;
+			self.weapons[weapon_index].weapon_magazine = weapon_fixup_storage[i].weapon_magazine;
+			self.weapons[weapon_index].weapon_magazine_left = weapon_fixup_storage[i].weapon_magazine_left;
+			self.weapons[weapon_index].weapon_reserve = weapon_fixup_storage[i].weapon_reserve;
+			self.weapons[weapon_index].weapon_skin = weapon_fixup_storage[i].weapon_skin;
+			self.weapons[weapon_index].weapon_tier = weapon_fixup_storage[i].weapon_tier;
+			self.weapons[weapon_index].is_mulekick_weapon = weapon_fixup_storage[i].is_mulekick_weapon;
 			weapon_index++;
 		}
 	}


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Uses temporary storage for the weapon utilities, gets Vril loading into Gun Game
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
