### PR TITLE
SERVER: Fixed Raygun Reload not showing the Crosshair after finishing

### DIFF
--- a/source/server/weapons/weapon_core.qc
+++ b/source/server/weapons/weapon_core.qc
@@ -325,6 +325,12 @@ void(float side) W_Give_Ammo =
 	} else {
 		self.weapons[0].weapon_magazine += loadammo;
 	}
+
+	//Fixes an issue with the raygun not showing the crosshair after reloading (still not sure of the root cause)
+	//Checks specifically for Raygun as it'd make the crosshair show up too early for certain weapons during their animations.
+	if (self.weapon == W_RAY){
+		W_ShowCrosshair(self);
+	}
 };
 
 void () W_LoadAmmo;

--- a/source/server/weapons/weapon_core.qc
+++ b/source/server/weapons/weapon_core.qc
@@ -326,9 +326,12 @@ void(float side) W_Give_Ammo =
 		self.weapons[0].weapon_magazine += loadammo;
 	}
 
-	//Fixes an issue with the raygun not showing the crosshair after reloading (still not sure of the root cause)
-	//Checks specifically for Raygun as it'd make the crosshair show up too early for certain weapons during their animations.
-	if (self.weapon == W_RAY){
+	float endframe, reloadcancelframe;
+	endframe = GetFrame(self.weapon, RELOAD_END);
+	reloadcancelframe = GetFrame(self.weapon, RELOAD_CANCEL);
+
+	//Mainly fixes an issue with the raygun not showing the crosshair after reloading (due to no cancel reload frame being added)
+	if (self.weaponframe == endframe && reloadcancelframe <= endframe){
 		W_ShowCrosshair(self);
 	}
 };


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
Fixes "Crosshair is hidden after reloading Ray Gun" (https://github.com/nzp-team/nzportable/issues/1225) by checking if current weapon is Raygun and then showing the Crosshair in W_Give_Ammo.

The check is there to make sure the crosshair doesn't display too early for other weapon reloads.

### Visual Sample
Before:

https://github.com/user-attachments/assets/4006a118-8bfb-4ccd-ba23-a37b98e05a23

After:

https://github.com/user-attachments/assets/58f4763c-72a3-4246-bea0-0a26dd5d48f5




### Checklist
---

- [X] I have thoroughly tested my changes to the best of my ability
- [X] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
