### PR TITLE
CLIENT/MENU: Added Crosshair Dot accessibility setting

### DIFF
--- a/source/client/hud.qc
+++ b/source/client/hud.qc
@@ -1645,7 +1645,8 @@ void() HUD_Crosshair =
 	if (getstatf(STAT_HEALTH) < 1)
 		return;
 	
-	if (cvar("cl_crosshairdot")){
+	//Dot + AOE doesnt look good cause AOE  crosshair isn't 100% centered
+	if (cvar("cl_crosshairdot") && crosshair_value != 2){ 
 		drawfill([g_width, g_height] / 2 - [2, 2], [4, 4], crosshair_color, crosshair_opacity, 0); // dot
 	}
 

--- a/source/client/hud.qc
+++ b/source/client/hud.qc
@@ -1644,11 +1644,6 @@ void() HUD_Crosshair =
 	
 	if (getstatf(STAT_HEALTH) < 1)
 		return;
-	
-	//Dot + AOE doesnt look good cause AOE  crosshair isn't 100% centered
-	if (cvar("cl_crosshairdot") && crosshair_value != 2){ 
-		drawfill([g_width, g_height] / 2 - [2, 2], [4, 4], crosshair_color, crosshair_opacity, 0); // dot
-	}
 
 	// Standard crosshair (+)
 	if (crosshair_value == 1) {
@@ -1668,6 +1663,21 @@ void() HUD_Crosshair =
 		// Creds to heartologic for some actually good crosshair position stuff.
 		vector crossSize = [1, 5];
 		vector screenSize = [g_width, g_height];
+
+		if (cvar("cl_crosshairdot")){ 
+			//doing all of this cause it's easier to look at & cause we don't know the size of the dot yet
+			//and doing calculations again would make it be harder to edit/test
+			local int dot_size_factor = cvar("cl_crosshairdot_size");
+
+			if (!dot_size_factor)
+				dot_size_factor = 6;
+
+			local vector dot_pos = [g_width, g_height] / 2;
+			local vector dot_size = [4 + crosshair_offset, 4 + crosshair_offset] / dot_size_factor;
+			dot_pos -= (dot_size / 2);
+
+			drawfill(dot_pos, dot_size, crosshair_color, crosshair_opacity, 0); // dot
+		}
 
 		drawfill(screenSize / 2 - [crossSize.x, +crossSize.y * 2 + crosshair_offset_step], crossSize, crosshair_color, crosshair_opacity, 0); // top
 		drawfill(screenSize / 2 - [crossSize.x, -crossSize.y * 1 - crosshair_offset_step + 2], crossSize, crosshair_color, crosshair_opacity, 0); // bottom

--- a/source/client/hud.qc
+++ b/source/client/hud.qc
@@ -1644,6 +1644,10 @@ void() HUD_Crosshair =
 	
 	if (getstatf(STAT_HEALTH) < 1)
 		return;
+	
+	if (cvar("cl_crosshairdot")){
+		drawfill([g_width, g_height] / 2 - [2, 2], [4, 4], crosshair_color, crosshair_opacity, 0); // dot
+	}
 
 	// Standard crosshair (+)
 	if (crosshair_value == 1) {

--- a/source/client/main.qc
+++ b/source/client/main.qc
@@ -156,6 +156,7 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init =
 	autocvar(cl_hitmarkers, 1);
 	autocvar(cl_textopacity, 0.20);
 	autocvar(cl_colorblind, 0);
+	autocvar(cl_crosshairdot, 0);
 
 	autocvar(scr_playerdebuginfo, 0);
 	autocvar(scr_playerdebuginfo_x, 64);

--- a/source/menu/main.qc
+++ b/source/menu/main.qc
@@ -228,6 +228,7 @@ void() m_init =
 	autocvar(cl_hitmarkers, 1);
 	autocvar(cl_textopacity, 0.20);
 	autocvar(cl_colorblind, 0);
+	autocvar(cl_crosshairdot, 0);
 
 	autocvar(sv_gamemode, 0);
 	autocvar(sv_difficulty, 0);

--- a/source/menu/menu_aces.qc
+++ b/source/menu/menu_aces.qc
@@ -1,4 +1,4 @@
-string menu_accesibility_buttons[7] = {"ac_hitm", "ac_text", "ac_color", "ac_whiteflash", "ac_monthspoof", "ac_apply", "ac_back"};
+string menu_accesibility_buttons[8] = {"ac_hitm", "ac_text", "ac_color", "ac_whiteflash", "ac_monthspoof", "ac_apply", "ac_crosshairdot", "ac_back"};
 
 float menu_accessibility_init;
 
@@ -6,6 +6,7 @@ float current_hitmarker;
 float current_colorblind;
 float current_whiteflash;
 float current_monthspoof;
+float current_crosshairdot;
 
 string(string prev_id) Menu_Accessibility_GetNextButton =
 {
@@ -53,6 +54,7 @@ void() Menu_Accessibility_StoreCurrentSettings =
     current_colorblind = cvar("cl_colorblind");
     current_whiteflash = cvar("scr_whiteflash");
     current_monthspoof = cvar("sv_spoofmonth");
+    current_crosshairdot = cvar("cl_crosshairdot");
 }
 
 void() Menu_Accessibility_ApplySettings =
@@ -72,6 +74,13 @@ void() Menu_Accessibility_UpdateHitmarkers =
     Menu_PlaySound(MENU_SND_ENTER);
     current_hitmarker = !current_hitmarker;
     cvar_set("cl_hitmarkers", ftos(current_hitmarker));
+};
+
+void() Menu_Accessibility_UpdateCrosshairDot =
+{
+    Menu_PlaySound(MENU_SND_ENTER);
+    current_crosshairdot = !current_crosshairdot;
+    cvar_set("cl_crosshairdot", ftos(current_crosshairdot));
 };
 
 void() Menu_Accessibility_UpdateColorblindFilter =
@@ -158,6 +167,15 @@ void() Menu_Accessibility =
         default: break;
     }
     Menu_DrawOptionValue(5, month_string);
+
+    Menu_Button(6, "ac_crosshairdot", "CROSSHAIR DOT", "Add a dot to the middle of the crosshair.") ? Menu_Accessibility_UpdateCrosshairDot() : 0;
+    string crosshair_string = "";
+    switch(current_crosshairdot) {
+        case 0: crosshair_string = "DISABLED"; break;
+        case 1: crosshair_string = "ENABLED"; break;
+        default: break;
+    }
+    Menu_DrawOptionValue(6, crosshair_string);
 
     Menu_DrawDivider(12.25);
     Menu_Button(-2, "ac_apply", "APPLY", "Save & Apply Settings.") ? Menu_Accessibility_ApplySettings() : 0;


### PR DESCRIPTION
### Description of Changes

Implements "Add center dot as an option in Accessibility." (https://github.com/nzp-team/nzportable/issues/1305)

Added a new client variable "cl_crosshairdot" and button to the Accessibility Settings Menu screen.
It displays a dot in the middle of the crosshair when enabled.

### Visual Sample

https://github.com/user-attachments/assets/7678664f-8559-40e7-8a33-ba0c75eb4321

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
