### PR TITLE
Standard build: fix mid-round join dead-end and unknown-gamemode crash

### DIFF
--- a/source/server/gamemodes/core.qc
+++ b/source/server/gamemodes/core.qc
@@ -65,7 +65,13 @@ void() Gamemode_Init =
         case GAMEMODE_STICKSNSTONES: Gamemode_Sticks_Init(); break;
         case GAMEMODE_WILDWEST: Gamemode_WW_Init(); break;
         case GAMEMODE_FESTIVE: Gamemode_Festive_Init(); break;
-        default: error("Received unrecognized gamemode."); break;
+        default:
+            // unimplemented (e.g. GRIEF) or garbage value — fall back
+            // to CLASSIC instead of error()ing out of the progs.
+            bprint(PRINT_HIGH, "[WARN]: Unrecognized gamemode, falling back to CLASSIC.\n");
+            current_gamemode = GAMEMODE_CLASSIC;
+            cvar_set("sv_gamemode", "0");
+            break;
     }
 };
 

--- a/source/server/player/player_core.qc
+++ b/source/server/player/player_core.qc
@@ -1167,11 +1167,10 @@ void() PutClientInServer =
 	
 	if (spawn_time > time || !rounds)
 		PlayerSpawn();
+	else
+		SpectatorSpawn();
 
 #ifdef FTE
-
-	else 
-		SpectatorSpawn();
 
 	// Force the client to always be networked to other clients, even when
 	// outside of the same PVS.


### PR DESCRIPTION
## What this fixes

Two small server-QC issues that block coop on the standard (non-FTE) build — found while bringing AdHoc multiplayer back to life on PSP (companion PR: nzp-team/vril-engine#155).

1. **Mid-round join dead-end** (`player_core.qc`, PutClientInServer): the `else SpectatorSpawn();` fallback for a client who connects after a round has started was inside `#ifdef FTE`. On the standard build a late joiner got neither PlayerSpawn nor SpectatorSpawn — a classnameless, modelless entity stuck at the world origin that never enters the game. Since a second PSP normally connects while the host is already mid-round, this broke the default coop join path. The fallback is now unconditional; `SpectatorSpawn`/`startspectate` already compile and work on standard, and `EndRound` already converts spectators into players at the next round transition. The `PVSF_IGNOREPVS` / `FTE_IncrementRound` lines stay FTE-only.

2. **Unknown-gamemode hard crash** (`gamemodes/core.qc`): `Gamemode_Init` called `error()` for any unimplemented `sv_gamemode` value (e.g. 1 = GRIEF, or garbage from a config), killing the progs at worldspawn. It now warns and falls back to CLASSIC.

## Validation

Built all four targets with `tools/qc-compiler-gnu.sh` (FTE CSQC/SSQC/MenuQC + Vril SSQC, clean). Verified end-to-end on PPSSPP with the engine PR: a client joining mid-round enters as a spectator and spawns as a real player (weapon + starting points) on the next round transition; 2-player scoreboard and revive prompts work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)