### PR TITLE
SERVER: Enable enhanced toasts and hitmarkers for Vril

### DIFF
--- a/source/server/clientfuncs.qc
+++ b/source/server/clientfuncs.qc
@@ -237,6 +237,7 @@ void(entity who, float death_marker) nzp_hitmarker =
 
 	msg_entity = who;
 	WriteByte(MSG_ONE, SVC_HITMARK);
+	WriteByte(MSG_ONE, death_marker);
 		
 #endif // FTE
 

--- a/source/server/defs/standard.qc
+++ b/source/server/defs/standard.qc
@@ -270,7 +270,7 @@ string(float num)                                                               
 string  (string s)                                                                              strtolower          = #480;
 float   (float caseinsensitive, string s)                                                       crc16               = #494;
 void    (string trackname)                                                                    	songegg             = #500;
-void    ()                                                                                   	nzp_poweruptoast    = #501;
+void    (float powerup_id)                                                                      nzp_poweruptoast    = #501;
 void    (entity who)                                                                            grenade_pulse       = #502;
 float   ()                                                                                      nzp_maxai           = #503;
 void    (entity who)                                                                            nzp_bettyprompt     = #504;

--- a/source/server/entities/powerups.qc
+++ b/source/server/entities/powerups.qc
@@ -911,13 +911,8 @@ void() PU_Touch =
 		// Run Power-Up function
 		PU_LogicFunction(self.walktype);
 
-#ifdef FTE
 		if (game_modifier_powerup_toast_for_all == true || self.walktype == PU_MAXAMMO)
 			nzp_poweruptoast(self.walktype);
-#else
-		if (self.walktype == PU_MAXAMMO)
-			nzp_poweruptoast();
-#endif // FTE
 	}
 };
 

--- a/source/server/gamemodes/festive.qc
+++ b/source/server/gamemodes/festive.qc
@@ -236,6 +236,8 @@ float(float current_melee_damage, float weapon, float has_bowie) Gamemode_Festiv
 
 float(float current_count, float current_round, float round_type, float current_player_count) Gamemode_Festive_GetZombieTotalForRound =
 {
+    float zombie_count = 0;
+    
     // Leave Hellhounds alone..
     if (round_type == 2)
         return current_count;
@@ -329,7 +331,7 @@ float(float current_count, float current_round, float round_type, float current_
             multiplier = current_round * player_weight;
         }
 
-        float zombie_count = rint(algo_magic * 6 * multiplier);
+        zombie_count = rint(algo_magic * 6 * multiplier);
     }
 
     return zombie_count;

--- a/tools/qc-compiler-gnu.sh
+++ b/tools/qc-compiler-gnu.sh
@@ -96,7 +96,7 @@ function main()
 	compile_progs "csqc" "FTE CSQC" "-DFTE -Wall"
 	compile_progs "ssqc" "FTE SSQC" "-O3 -DFTE ${TEST_FLAG} -Wall"
 	compile_progs "menu" "FTE MenuQC" "-O3 -DFTE -Wall"
-	compile_progs "ssqc" "Vril SSQC" "-O3 -Wall"
+	compile_progs "ssqc" "Vril SSQC" "-O3 -Ono-compound_jumps -Wall"
 	exit ${RC}
 }
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Sends the death byte for hitmarkers and the powerup id to nzp_powerup toast for Vril to enable those HUD features.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
