### PR TITLE
SERVER: Added Damage Type Trigger to func_button

### DIFF
--- a/source/server/damage.qc
+++ b/source/server/damage.qc
@@ -454,48 +454,29 @@ float(float min, float max, vector org1, vector org2, float radius) calculate_pr
 	return proximity_value;
 };
 
-#define SPAWNFLAG_FUNCBUTTON_FIREDAMAGE		1
-#define FUNC_ALLOW_UPGRADE		1
-#define FUNC_ALLOW_BULLET		2
-#define FUNC_ALLOW_EXPLOSIVE		4
-#define FUNC_ALLOW_FIRE		6
-#define FUNC_ALLOW_RAY		8
-#define FUNC_ALLOW_MELEE		10
-
-int(int damage_type, entity hit_ent) CanAttackButton = 
+int(int damage_type, entity hit_ent, entity attacker) CanAttackButton = 
 {
+	//No Weapon Flags
 	if (hit_ent.weapon == 0)
 		return true;
 
-	bprint(PRINT_HIGH, strcat("\nTEST WITH ME | ", ftos(hit_ent.weapon)));
-	bprint(PRINT_HIGH,strcat("\nI AM ALIVE!! but no pap?: ", ftos(EqualPapWeapon(self.weapons[0].weapon_id) == self.owner.weapons[0].weapon_id)));
-	bprint(PRINT_HIGH,strcat("\nWEAPON: : ", ftos(self.weapons[0].weapon_id)));
-	bprint(PRINT_HIGH,"\n");
-
 	int pap_check = false;
-	if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (self.weapons[0].weapon_id != EqualPapWeapon(self.weapons[0].weapon_id))){
-		bprint(PRINT_HIGH,"\nYES BUT NO PAP!");
-		bprint(PRINT_HIGH,"\n");
+	if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (attacker.weapons[0].weapon_id != EqualPapWeapon(attacker.weapons[0].weapon_id))){;
 		return false;
 	}else{
-		if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (self.weapons[0].weapon_id == EqualPapWeapon(self.weapons[0].weapon_id))){
+		if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (attacker.weapons[0].weapon_id == EqualPapWeapon(attacker.weapons[0].weapon_id))){
 			pap_check = true;
 		}
 	}
 
 	int result = (hit_ent.weapon & damage_type);
 	if (result != damage_type && !pap_check) {
-		bprint(PRINT_HIGH,"\nNO BULLET!\n");
-		bprint(PRINT_HIGH,strcat("\nBULLET ALLOW DEFINE: ", ftos(damage_type)));
-		bprint(PRINT_HIGH,strcat("\nUPGRADE ALLOW DEFINE: ", ftos(damage_type)));
-		//bprint(PRINT_HIGH,strcat("\nBULLET IS FALSE: ", ftos(hit_ent.weapon & ~damage_type)));
-		bprint(PRINT_HIGH,strcat("\nBULLET IS TRUE: ", ftos(hit_ent.weapon & damage_type)));
-		bprint(PRINT_HIGH,"\n");
 		return false;
+	}else if (result != damage_type && pap_check){
+		if (hit_ent.weapon != pap_check) //if there is a upgrade flag, but it's not 100% just that, then return out
+			return false;
 	}
 
-	bprint(PRINT_HIGH,strcat("\nRESULTS: ", ftos(result)));
-	bprint(PRINT_HIGH,"\n");
 	return true;
 }
 void(entity inflictor, entity attacker, float damage2, float mindamage, float radius) DamgageExplode =
@@ -507,7 +488,7 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 	float 	multi, r;
 	ent = findradius(inflictor.origin, radius);
 	
-	while (ent)
+	while (ent != world)
 	{
 		if(ent.classname == "player")
 		{
@@ -594,7 +575,7 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 			teddy_react();
 			self = oldself2;
 		}
-		else if (ent.takedamage && ent.classname != "ai_zombie_head" && ent.classname != "ai_zombie_larm" && ent.classname != "ai_zombie_rarm")
+		else if (ent.takedamage && ent.classname != "func_button" && ent.classname != "ai_zombie_head" && ent.classname != "ai_zombie_larm" && ent.classname != "ai_zombie_rarm")
 		{
 			if (mapname == "ndu" && ent.classname == "ai_zombie" && inflictor.classname == "explosive_barrel") {
 				ach_tracker_barr++;
@@ -658,35 +639,53 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 				ent.crawling = 2;
 			}	
 		}
-		else if (ent.solid == SOLID_BSP && ent.classname == "func_button"){
+		else if (ent.classname == "func_button"){
 			int do_not_attack = false;
-			switch(attacker.weapons[0].weapon_id){
-				case W_RAY:
-					if (CanAttackButton(FUNC_ALLOW_RAY, ent)){
-						//Not sure if this is needed, but I just copied the grenade code
-						final_damage = rounds + rint(random() * 350) + 150;
-						damage_style = DMG_TYPE_GRENADE;	
-					}else
+			
+			switch(inflictor.classname){
+				case "projectile_raybeam":
+					if (!CanAttackButton(FUNC_ALLOW_RAY, ent, attacker)){
 						do_not_attack = true;
+					}
 					break;
 				
-				case W_GRENADE:
-					if (CanAttackButton(FUNC_ALLOW_EXPLOSIVE, ent)){
-						//Not sure if this is needed, but I just copied the grenade code
-						final_damage = rounds + rint(random() * 350) + 150;
-						damage_style = DMG_TYPE_GRENADE;	
-					}else
+				case "grenade":
+				case "rocket":
+				case "projectile_grenade":
+					if (!CanAttackButton(FUNC_ALLOW_EXPLOSIVE, ent, attacker)){
 						do_not_attack = true;
+					}
+					break;
+				
+				default:
+					do_not_attack = true;
 					break;
 			}	
-			if (do_not_attack)
-					continue;
-			} 
+
+			if (do_not_attack){
+				ent = ent.chain;
+				continue;
+			}
+			else{ //needed or else the game gets stuck into an infinite loop somehow
+				entity oldself;
+				oldself = self;
+				self = ent;
+				self.health -= self.max_health + 1;
+				self.enemy = oldself;
+
+				if (self.health < 0)
+					self.th_die();
+				self = oldself;
+				ent = ent.chain;
+				continue;
+			}
+		} 
 
 		if (final_damage > 0) {
 			if (CanDamage (ent, inflictor))
 				DamageHandler (ent, attacker, final_damage, damage_style);
 		}
+		
 		ent = ent.chain;
 	}
 };

--- a/source/server/damage.qc
+++ b/source/server/damage.qc
@@ -454,6 +454,50 @@ float(float min, float max, vector org1, vector org2, float radius) calculate_pr
 	return proximity_value;
 };
 
+#define SPAWNFLAG_FUNCBUTTON_FIREDAMAGE		1
+#define FUNC_ALLOW_UPGRADE		1
+#define FUNC_ALLOW_BULLET		2
+#define FUNC_ALLOW_EXPLOSIVE		4
+#define FUNC_ALLOW_FIRE		6
+#define FUNC_ALLOW_RAY		8
+#define FUNC_ALLOW_MELEE		10
+
+int(int damage_type, entity hit_ent) CanAttackButton = 
+{
+	if (hit_ent.weapon == 0)
+		return true;
+
+	bprint(PRINT_HIGH, strcat("\nTEST WITH ME | ", ftos(hit_ent.weapon)));
+	bprint(PRINT_HIGH,strcat("\nI AM ALIVE!! but no pap?: ", ftos(EqualPapWeapon(self.weapons[0].weapon_id) == self.owner.weapons[0].weapon_id)));
+	bprint(PRINT_HIGH,strcat("\nWEAPON: : ", ftos(self.weapons[0].weapon_id)));
+	bprint(PRINT_HIGH,"\n");
+
+	int pap_check = false;
+	if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (self.weapons[0].weapon_id != EqualPapWeapon(self.weapons[0].weapon_id))){
+		bprint(PRINT_HIGH,"\nYES BUT NO PAP!");
+		bprint(PRINT_HIGH,"\n");
+		return false;
+	}else{
+		if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (self.weapons[0].weapon_id == EqualPapWeapon(self.weapons[0].weapon_id))){
+			pap_check = true;
+		}
+	}
+
+	int result = (hit_ent.weapon & damage_type);
+	if (result != damage_type && !pap_check) {
+		bprint(PRINT_HIGH,"\nNO BULLET!\n");
+		bprint(PRINT_HIGH,strcat("\nBULLET ALLOW DEFINE: ", ftos(damage_type)));
+		bprint(PRINT_HIGH,strcat("\nUPGRADE ALLOW DEFINE: ", ftos(damage_type)));
+		//bprint(PRINT_HIGH,strcat("\nBULLET IS FALSE: ", ftos(hit_ent.weapon & ~damage_type)));
+		bprint(PRINT_HIGH,strcat("\nBULLET IS TRUE: ", ftos(hit_ent.weapon & damage_type)));
+		bprint(PRINT_HIGH,"\n");
+		return false;
+	}
+
+	bprint(PRINT_HIGH,strcat("\nRESULTS: ", ftos(result)));
+	bprint(PRINT_HIGH,"\n");
+	return true;
+}
 void(entity inflictor, entity attacker, float damage2, float mindamage, float radius) DamgageExplode =
 {
 	float 	final_damage = 0;
@@ -463,7 +507,7 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 	float 	multi, r;
 	ent = findradius(inflictor.origin, radius);
 	
-	while (ent != world)
+	while (ent)
 	{
 		if(ent.classname == "player")
 		{
@@ -614,6 +658,30 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 				ent.crawling = 2;
 			}	
 		}
+		else if (ent.solid == SOLID_BSP && ent.classname == "func_button"){
+			int do_not_attack = false;
+			switch(attacker.weapons[0].weapon_id){
+				case W_RAY:
+					if (CanAttackButton(FUNC_ALLOW_RAY, ent)){
+						//Not sure if this is needed, but I just copied the grenade code
+						final_damage = rounds + rint(random() * 350) + 150;
+						damage_style = DMG_TYPE_GRENADE;	
+					}else
+						do_not_attack = true;
+					break;
+				
+				case W_GRENADE:
+					if (CanAttackButton(FUNC_ALLOW_EXPLOSIVE, ent)){
+						//Not sure if this is needed, but I just copied the grenade code
+						final_damage = rounds + rint(random() * 350) + 150;
+						damage_style = DMG_TYPE_GRENADE;	
+					}else
+						do_not_attack = true;
+					break;
+			}	
+			if (do_not_attack)
+					continue;
+			} 
 
 		if (final_damage > 0) {
 			if (CanDamage (ent, inflictor))

--- a/source/server/damage.qc
+++ b/source/server/damage.qc
@@ -641,7 +641,7 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 		}
 		else if (ent.classname == "func_button"){
 			int do_not_attack = false;
-			
+
 			switch(inflictor.classname){
 				case "projectile_raybeam":
 					if (!CanAttackButton(FUNC_ALLOW_RAY, ent, attacker)){
@@ -667,7 +667,6 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 				continue;
 			}
 			else{ //needed or else the game gets stuck into an infinite loop somehow
-				entity oldself;
 				oldself = self;
 				self = ent;
 				self.health -= self.max_health + 1;

--- a/source/server/damage.qc
+++ b/source/server/damage.qc
@@ -456,12 +456,16 @@ float(float min, float max, vector org1, vector org2, float radius) calculate_pr
 
 int(int damage_type, entity hit_ent, entity attacker) CanAttackButton = 
 {
+	if ((hit_ent.spawnflags & SPAWNFLAG_FUNCBUTTON_FIREDAMAGE) && attacker.weapons[0].weapon_id != W_M2 && attacker.weapons[0].weapon_id != W_FIW){
+		return false;
+	}
+
 	//No Weapon Flags
 	if (hit_ent.weapon == 0)
 		return true;
 
 	int pap_check = false;
-	if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (attacker.weapons[0].weapon_id != EqualPapWeapon(attacker.weapons[0].weapon_id))){;
+	if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (attacker.weapons[0].weapon_id != EqualPapWeapon(attacker.weapons[0].weapon_id))){
 		return false;
 	}else{
 		if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (attacker.weapons[0].weapon_id == EqualPapWeapon(attacker.weapons[0].weapon_id))){
@@ -473,8 +477,9 @@ int(int damage_type, entity hit_ent, entity attacker) CanAttackButton =
 	if (result != damage_type && !pap_check) {
 		return false;
 	}else if (result != damage_type && pap_check){
-		if (hit_ent.weapon != pap_check) //if there is a upgrade flag, but it's not 100% just that, then return out
+		if (hit_ent.weapon != pap_check){ //if there is a upgrade flag, but it's not 100% just that, then return out
 			return false;
+		}
 	}
 
 	return true;

--- a/source/server/damage.qc
+++ b/source/server/damage.qc
@@ -454,7 +454,7 @@ float(float min, float max, vector org1, vector org2, float radius) calculate_pr
 	return proximity_value;
 };
 
-int(int damage_type, entity hit_ent, entity attacker) CanAttackButton = 
+float(float damage_type, entity hit_ent, entity attacker) CanDamageFunc = 
 {
 	if ((hit_ent.spawnflags & SPAWNFLAG_FUNCBUTTON_FIREDAMAGE) && attacker.weapons[0].weapon_id != W_M2 && attacker.weapons[0].weapon_id != W_FIW){
 		return false;
@@ -464,7 +464,7 @@ int(int damage_type, entity hit_ent, entity attacker) CanAttackButton =
 	if (hit_ent.weapon == 0)
 		return true;
 
-	int pap_check = false;
+	float pap_check = false;
 	if ((hit_ent.weapon & FUNC_ALLOW_UPGRADE) && (attacker.weapons[0].weapon_id != EqualPapWeapon(attacker.weapons[0].weapon_id))){
 		return false;
 	}else{
@@ -473,17 +473,34 @@ int(int damage_type, entity hit_ent, entity attacker) CanAttackButton =
 		}
 	}
 
-	int result = (hit_ent.weapon & damage_type);
+	float result = (hit_ent.weapon & damage_type);
 	if (result != damage_type && !pap_check) {
 		return false;
 	}else if (result != damage_type && pap_check){
-		if (hit_ent.weapon != pap_check){ //if there is a upgrade flag, but it's not 100% just that, then return out
+		//do direct check so we dont trigger it when ifi it requires a upgraded flamethrower
+		//when we have a upgraded .357 
+		if (hit_ent.weapon != FUNC_ALLOW_UPGRADE){
 			return false;
 		}
 	}
 
 	return true;
 }
+
+void(entity func, entity attacker, float damage) DamageFunc =
+{
+	entity oldself;
+	oldself = self;
+	self = trace_ent;
+	self.health -= damage;
+	self.enemy = oldself;
+
+	if (self.health <= 0)
+		self.th_die();
+	
+	self = oldself;
+}
+
 void(entity inflictor, entity attacker, float damage2, float mindamage, float radius) DamgageExplode =
 {
 	float 	final_damage = 0;
@@ -645,11 +662,11 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 			}	
 		}
 		else if (ent.classname == "func_button"){
-			int do_not_attack = false;
+			float do_not_attack = false;
 
 			switch(inflictor.classname){
 				case "projectile_raybeam":
-					if (!CanAttackButton(FUNC_ALLOW_RAY, ent, attacker)){
+					if (!CanDamageFunc(FUNC_ALLOW_RAY, ent, attacker)){
 						do_not_attack = true;
 					}
 					break;
@@ -657,7 +674,7 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 				case "grenade":
 				case "rocket":
 				case "projectile_grenade":
-					if (!CanAttackButton(FUNC_ALLOW_EXPLOSIVE, ent, attacker)){
+					if (!CanDamageFunc(FUNC_ALLOW_EXPLOSIVE, ent, attacker)){
 						do_not_attack = true;
 					}
 					break;
@@ -688,8 +705,7 @@ void(entity inflictor, entity attacker, float damage2, float mindamage, float ra
 		if (final_damage > 0) {
 			if (CanDamage (ent, inflictor))
 				DamageHandler (ent, attacker, final_damage, damage_style);
-		}
-		
+		}		
 		ent = ent.chain;
 	}
 };

--- a/source/server/entities/func.qc
+++ b/source/server/entities/func.qc
@@ -401,8 +401,7 @@ void() func_button =
 	if (self.health) {
 		self.max_health = self.health;
 		self.th_die = button_killed;
-		self.takedamage = DAMAGE_YES;
-		
+		self.takedamage = DAMAGE_YES;		
 	} else {
 		self.touch = button_touch;
     }

--- a/source/server/entities/func.qc
+++ b/source/server/entities/func.qc
@@ -295,7 +295,6 @@ void() func_train =
 // func_button
 // =================================
 
-#define SPAWNFLAG_FUNCBUTTON_FIREDAMAGE		1
 
 void() button_wait;
 void() button_return;
@@ -403,6 +402,7 @@ void() func_button =
 		self.max_health = self.health;
 		self.th_die = button_killed;
 		self.takedamage = DAMAGE_YES;
+		
 	} else {
 		self.touch = button_touch;
     }

--- a/source/server/weapons/ballistic_knife.qc
+++ b/source/server/weapons/ballistic_knife.qc
@@ -57,16 +57,8 @@ void(entity victim) Blade_Damage =
 			}
 			break;
 		case "func_button":
-			if (CanAttackButton(FUNC_ALLOW_MELEE, victim, self.owner)){
-				entity oldself;
-				oldself = self;
-				self = victim;
-				self.health -= self.max_health;
-				self.enemy = oldself;
-
-				if (self.health < 0)
-					self.th_die();
-				self = oldself;
+			if (CanDamageFunc(FUNC_ALLOW_MELEE, victim, self.owner)){
+				DamageFunc(victim, self.owner, victim.max_health);
 			}
 
 			self.angles_y = 180;

--- a/source/server/weapons/ballistic_knife.qc
+++ b/source/server/weapons/ballistic_knife.qc
@@ -56,6 +56,21 @@ void(entity victim) Blade_Damage =
                 damage_type = DMG_TYPE_UPPERTORSO;
 			}
 			break;
+		case "func_button":
+			if (CanAttackButton(FUNC_ALLOW_MELEE, victim, self.owner)){
+				entity oldself;
+				oldself = self;
+				self = victim;
+				self.health -= self.max_health;
+				self.enemy = oldself;
+
+				if (self.health < 0)
+					self.th_die();
+				self = oldself;
+			}
+
+			self.angles_y = 180;
+			return;
 		default:
             damage_region = LOWER_TORSO_X;
             damage_type = DMG_TYPE_LOWERTORSO;

--- a/source/server/weapons/flamethrower.qc
+++ b/source/server/weapons/flamethrower.qc
@@ -72,7 +72,7 @@ void() Flame_Touch =
 	} 
 	// Support for func_button
 	if (target.classname == "func_button") {
-		if (!CanAttackButton(FUNC_ALLOW_FIRE, target, self)){
+		if (!CanAttackButton(FUNC_ALLOW_FIRE, target, self.owner)){
 			return;
 		}
 		
@@ -80,7 +80,7 @@ void() Flame_Touch =
 
 		old_self = self;
 		self = target;
-		self.health -= 50;
+		self.health -= self.max_health + 1;
 		self.enemy = old_self.owner;
 
 		if (self.health < 0)

--- a/source/server/weapons/flamethrower.qc
+++ b/source/server/weapons/flamethrower.qc
@@ -72,20 +72,11 @@ void() Flame_Touch =
 	} 
 	// Support for func_button
 	if (target.classname == "func_button") {
-		if (!CanAttackButton(FUNC_ALLOW_FIRE, target, self.owner)){
+		if (!CanDamageFunc(FUNC_ALLOW_FIRE, target, self.owner)){
 			return;
 		}
 		
-		entity old_self;
-
-		old_self = self;
-		self = target;
-		self.health -= self.max_health + 1;
-		self.enemy = old_self.owner;
-
-		if (self.health < 0)
-			self.th_die();
-		self = old_self;
+		DamageFunc(target, self.owner, 50);
 	}
 	// Some other entity
 	else {

--- a/source/server/weapons/flamethrower.qc
+++ b/source/server/weapons/flamethrower.qc
@@ -71,7 +71,11 @@ void() Flame_Touch =
 		remove(self);
 	} 
 	// Support for func_button
-	if (target.classname == "func_button" && target.spawnflags & SPAWNFLAG_FUNCBUTTON_FIREDAMAGE) {
+	if (target.classname == "func_button") {
+		if (!CanAttackButton(FUNC_ALLOW_FIRE, target, self)){
+			return;
+		}
+		
 		entity old_self;
 
 		old_self = self;

--- a/source/server/weapons/tesla.qc
+++ b/source/server/weapons/tesla.qc
@@ -295,6 +295,13 @@ void() W_FireTesla =
 	self.tesla_n_kills = 0;
     
     entity hit_ent = trace_ent;
+
+    if (hit_ent.classname == "func_button"){
+        if (CanDamageFunc(FUNC_ALLOW_ELECTRIC, hit_ent, self.owner)){
+            DamageFunc(hit_ent, self.owner, hit_ent.max_health);
+        }
+    }
+
 	if(hit_ent.classname == "ai_zombie_head" || hit_ent.classname == "ai_zombie_larm" || hit_ent.classname == "ai_zombie_rarm")
 		hit_ent = hit_ent.owner;
 

--- a/source/server/weapons/weapon_core.qc
+++ b/source/server/weapons/weapon_core.qc
@@ -857,12 +857,12 @@ void(float damage, vector dir, vector org, vector plane, entity hit_ent, float s
 		} else if (hit_ent.solid == SOLID_BSP) {
 			// Button only accepts Fire damage
 			if (hit_ent.classname == "func_button"){
-				//Compatibility
+				//fixes melee bypass
 				if (hit_ent.spawnflags & SPAWNFLAG_FUNCBUTTON_FIREDAMAGE){
 					return;
 				}
 
-				if (!CanAttackButton(FUNC_ALLOW_BULLET, hit_ent, self)){
+				if (!CanDamageFunc(FUNC_ALLOW_BULLET, hit_ent, self)){
 					return;
 				}
 
@@ -979,7 +979,6 @@ void (float shotcount, float sprd, float Damage, float side) FireTrace =
 #endif // FTE
 
 			if (trace_fraction != 1.0)
-
 				TraceAttack (Damage, dir, trace_endpos, trace_plane_normal, trace_ent, side);
 			trace_start_org = trace_endpos;
 			penetration_times++;
@@ -1338,16 +1337,8 @@ void() WeaponCore_Melee =
 		if (trace_ent.owner.head == trace_ent || trace_ent.owner.larm == trace_ent || trace_ent.owner.rarm == trace_ent)
 			trace_ent = trace_ent.owner;
 		
-		if (trace_ent.classname == "func_button" && CanAttackButton(FUNC_ALLOW_MELEE, trace_ent, self)){
-			entity oldself;
-			oldself = self;
-			self = trace_ent;
-			self.health -= self.max_health;
-			self.enemy = oldself;
-
-			if (self.health < 0)
-				self.th_die();
-			self = oldself;
+		if (trace_ent.classname == "func_button" && CanDamageFunc(FUNC_ALLOW_MELEE, trace_ent, self)){
+			DamageFunc(trace_ent, self, trace_ent.max_health);
 		}
 
 		// Target does not take damage -- no need to go any further
@@ -1391,7 +1382,6 @@ void() WeaponCore_Melee =
 
 			// Apply damage to the entity.
 			if (trace_ent.takedamage) {
-
 				float melee_damage = WepDef_CalculateMeleeDamage(self.weapon, self.has_bowie_knife);
 				DamageHandler (trace_ent, self, melee_damage, DMG_TYPE_MELEE);
 			}

--- a/source/server/weapons/weapon_core.qc
+++ b/source/server/weapons/weapon_core.qc
@@ -862,7 +862,7 @@ void(float damage, vector dir, vector org, vector plane, entity hit_ent, float s
 					return;
 				}
 
-				if (!CanAttackButton(FUNC_ALLOW_BULLET, hit_ent)){
+				if (!CanAttackButton(FUNC_ALLOW_BULLET, hit_ent, self)){
 					return;
 				}
 
@@ -1337,6 +1337,18 @@ void() WeaponCore_Melee =
 		// Check if this is a Zombie limb, set to the body if so
 		if (trace_ent.owner.head == trace_ent || trace_ent.owner.larm == trace_ent || trace_ent.owner.rarm == trace_ent)
 			trace_ent = trace_ent.owner;
+		
+		if (trace_ent.classname == "func_button" && CanAttackButton(FUNC_ALLOW_MELEE, trace_ent, self)){
+			entity oldself;
+			oldself = self;
+			self = trace_ent;
+			self.health -= self.max_health;
+			self.enemy = oldself;
+
+			if (self.health < 0)
+				self.th_die();
+			self = oldself;
+		}
 
 		// Target does not take damage -- no need to go any further
 		if (!trace_ent.takedamage && !(trace_ent.flags & FL_CLIENT)) {
@@ -1379,6 +1391,7 @@ void() WeaponCore_Melee =
 
 			// Apply damage to the entity.
 			if (trace_ent.takedamage) {
+
 				float melee_damage = WepDef_CalculateMeleeDamage(self.weapon, self.has_bowie_knife);
 				DamageHandler (trace_ent, self, melee_damage, DMG_TYPE_MELEE);
 			}

--- a/source/server/weapons/weapon_core.qc
+++ b/source/server/weapons/weapon_core.qc
@@ -856,8 +856,17 @@ void(float damage, vector dir, vector org, vector plane, entity hit_ent, float s
 			return;
 		} else if (hit_ent.solid == SOLID_BSP) {
 			// Button only accepts Fire damage
-			if (hit_ent.classname == "func_button" && (hit_ent.spawnflags & SPAWNFLAG_FUNCBUTTON_FIREDAMAGE))
-				return;
+			if (hit_ent.classname == "func_button"){
+				//Compatibility
+				if (hit_ent.spawnflags & SPAWNFLAG_FUNCBUTTON_FIREDAMAGE){
+					return;
+				}
+
+				if (!CanAttackButton(FUNC_ALLOW_BULLET, hit_ent)){
+					return;
+				}
+
+			}
 
 			oldself = self;
 			self = hit_ent;
@@ -970,6 +979,7 @@ void (float shotcount, float sprd, float Damage, float side) FireTrace =
 #endif // FTE
 
 			if (trace_fraction != 1.0)
+
 				TraceAttack (Damage, dir, trace_endpos, trace_plane_normal, trace_ent, side);
 			trace_start_org = trace_endpos;
 			penetration_times++;

--- a/source/shared/shared_defs.qc
+++ b/source/shared/shared_defs.qc
@@ -359,6 +359,16 @@ float 	map_compatibility_mode;
 #define GAMEMODE_STICKSNSTONES  5
 #define GAMEMODE_FESTIVE 		6
 
+// func_button
+#define SPAWNFLAG_FUNCBUTTON_FIREDAMAGE		1
+#define FUNC_ALLOW_UPGRADE		1
+#define FUNC_ALLOW_BULLET		2
+#define FUNC_ALLOW_EXPLOSIVE		4
+#define FUNC_ALLOW_FIRE		6
+#define FUNC_ALLOW_RAY		8
+#define FUNC_ALLOW_MELEE		10
+
+
 // Misc. player statistics
 .float playernum;
 .float is_spectator;

--- a/source/shared/shared_defs.qc
+++ b/source/shared/shared_defs.qc
@@ -367,7 +367,8 @@ float 	map_compatibility_mode;
 #define FUNC_ALLOW_EXPLOSIVE		4
 #define FUNC_ALLOW_FIRE		8
 #define FUNC_ALLOW_RAY		16
-#define FUNC_ALLOW_MELEE		32
+#define FUNC_ALLOW_ELECTRIC 	32
+#define FUNC_ALLOW_MELEE		64
 
 
 // Misc. player statistics

--- a/source/shared/shared_defs.qc
+++ b/source/shared/shared_defs.qc
@@ -361,12 +361,13 @@ float 	map_compatibility_mode;
 
 // func_button
 #define SPAWNFLAG_FUNCBUTTON_FIREDAMAGE		1
+
 #define FUNC_ALLOW_UPGRADE		1
 #define FUNC_ALLOW_BULLET		2
 #define FUNC_ALLOW_EXPLOSIVE		4
-#define FUNC_ALLOW_FIRE		6
-#define FUNC_ALLOW_RAY		8
-#define FUNC_ALLOW_MELEE		10
+#define FUNC_ALLOW_FIRE		8
+#define FUNC_ALLOW_RAY		16
+#define FUNC_ALLOW_MELEE		32
 
 
 // Misc. player statistics


### PR DESCRIPTION
### Description of Changes

Implements "Add shot type to func_button" (https://github.com/nzp-team/nzportable/issues/1319)
Added damage type triggers to func_button

Damage Types:
- None (Default)
- Upgraded Weapons Only
- Bullet
- Explosive
- Fire
- Raygun
- Melee

### Visual Sample
---

(left to right button damage types)
bullet + upgrade
none
upgrade
bullet
explosion

https://github.com/user-attachments/assets/c45db00e-6d3e-4b0e-80c9-3d92ae7b0e81



### Checklist
---

- [ X ] I have thoroughly tested my changes to the best of my ability
- [ X ] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
