### PR TITLE
CLIENT/SERVER: Refactor useprints to be controlled server-side, trigg…

### DIFF
--- a/progs/ssqc.src
+++ b/progs/ssqc.src
@@ -70,6 +70,7 @@ defs/standard.qc
 #endif
 shared_defs.qc
 defs/custom.qc
+useprints.qc
 fte_builtins.qc
 map_rotation.qc
 utilities/sound_helper.qc
@@ -149,6 +150,7 @@ tests/test_rounds.qc
 tests/test_game_counter.qc
 tests/test_player.qc
 tests/test_teleporter.qc
+tests/test_useprints.qc
 tests/test_list.qc
 tests/test_module.qc
 #endif

--- a/source/client/defs/custom.qc
+++ b/source/client/defs/custom.qc
@@ -43,9 +43,10 @@ float matchmake_enabled;
 float double_tap_version;
 
 float useprint_type;
-float useprint_weapon;
 float useprint_cost;
 float useprint_time;
+string useprint_strings[256];
+vector useprint_colors[256];
 
 float active_gamemode;
 

--- a/source/client/hud.qc
+++ b/source/client/hud.qc
@@ -1062,101 +1062,16 @@ void() HUD_Useprint =
 		}
 	}
 
-	switch (useprint_type) {
-		case 0://clear
-			usestring = "";
-			break;
-		case 1://door
-			usestring = strcat("Hold  ",usespace, " to open Door");
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 2://debris
-			usestring = strcat("Hold  ",usespace, " to remove Debris");
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 3://ammo
-			usestring = strcat("Hold  ",usespace, " to buy Ammo for ", getstats(STAT_WEAPONNAMETOUCH));
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 4://weapon
-			usestring = strcat("Hold  ",usespace, " to buy ", getstats(STAT_WEAPONNAMETOUCH));
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 5://window
-			usestring = strcat("Hold  ",usespace, " to Rebuild Barrier");
-			break;
-		case 6://box
-			usestring = strcat("Hold  ",usespace, " for Mystery Box");
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 7://box take
-			usestring = strcat("Hold  ",usespace, " for ", getstats(STAT_WEAPONNAMETOUCH));
-			break;
-		case 8://power
-			usestring = "The Power must be Activated first";
-			break;
-		case 9://perk
-			usestring = strcat("Hold  ",usespace, " to buy ", GetItemName(useprint_weapon));
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 10://turn on power
-			usestring = strcat("Hold  ",usespace, " to Turn On the Power");
-			break;
-		case 11://turn on trap
-			usestring = strcat("Hold  ",usespace, " to Activate the Trap");
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 12://packapunch
-			usestring = strcat("Hold  ",usespace, " to Pack-a-Punch");
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 13://revive
-			usestring = strcat("Hold  ",usespace, " to Revive Player");
-			break;
-		case 14://use teleporter (free)
-			usestring = strcat("Hold  ", usespace, " to use Teleporter");
-			break;
-		case 15://use teleporter (cost)
-			usestring = strcat("Hold  ", usespace, " to use Teleporter");
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 16://tp cooldown
-			usestring = "Teleporter is cooling down";
-			break;
-		case 17://link
-			usestring = strcat("Hold  ", usespace, " to initate link to pad");
-			break;
-		case 18://no link
-			usestring = "Link not active";
-			break;
-		case 19://finish link
-			usestring = strcat("Hold  ", usespace, " to link pad with core");
-			break;
-		case 20://buyable ending
-			usestring = strcat("Hold  ", usespace, " to End the Game");
-			usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
-			break;
-		case 21: // Magic disabled
-			usestring = "...";
-			break;
-		case 22: // Jugger-Nog (NIGHTMARE)
-			usestring = "It doesn't seem to be working..";
-			break;
-		case 23: // Tactical Nuke (Gun Game)
-			usestring = strcat("Hold ", usespace, " to Drop the Nuke");
-			break;
-		default:
-			usestring = "This should not happen you dum fuck"; //yikes
-			break;
-	}
+	usestring = useprint_strings[useprint_type];
+	usestring = strreplace("%s", getstats(STAT_USEPRINTTOUCH), usestring);
+	usestring = strreplace("%b", usespace, usestring);
+	if (useprint_cost > 0)
+		usecost = strcat("[Cost: ", ftos(useprint_cost), "]");
 
 	print_width = getTextWidth(usestring, 12);
 	x = (g_width - print_width)/2;
 
-	if (useprint_type == 22)
-		HUD_DrawStringWithBackdrop([x, g_height/2 + 65, 0], usestring, [12, 12, 0], [1, 0, 0], 1, 0);
-	else
-		HUD_DrawStringWithBackdrop([x, g_height/2 + 65, 0], usestring, [12, 12, 0], [1, 1, 1], 1, 0);
+	HUD_DrawStringWithBackdrop([x, g_height/2 + 65, 0], usestring, [12, 12, 0], useprint_colors[useprint_type], 1, 0);
 
 	// Draw "Cost" text.
 	if (usecost != "") {
@@ -1166,8 +1081,10 @@ void() HUD_Useprint =
 	}
 
 	// Draw highlighted usebutton
-	if (substring(usestring, 0, 4) == "Hold") {
-		button_width = x + getTextWidth("Hold ", 12);
+	if (strstrofs(useprint_strings[useprint_type], "%b") >= 0) {
+		string button_prefix = substring(useprint_strings[useprint_type], 0, strstrofs(useprint_strings[useprint_type], "%b"));
+		button_prefix = strreplace("%s", getstats(STAT_USEPRINTTOUCH), button_prefix);
+		button_width = x + getTextWidth(button_prefix, 12);
 
 		if (Key_IsControllerGlyph(usebutton))
 			Key_DrawControllerGlyph([button_width - 5, g_height/2 + 62], usebutton, [18, 18]);

--- a/source/client/main.qc
+++ b/source/client/main.qc
@@ -1217,8 +1217,16 @@ noref void() CSQC_Parse_Event =
 		case CSQC_EVENT_USEPRINT:
 			useprint_type = readbyte();
 			useprint_cost = readshort();
-			useprint_weapon = readbyte();
 			useprint_time = time + 0.1;
+			break;
+		case CSQC_EVENT_REGISTERUSEPRINT:
+			float useprint_index = readbyte();
+			useprint_strings[useprint_index] = readstring();
+			vector useprint_color;
+			useprint_color_x = readbyte() / 255;
+			useprint_color_y = readbyte() / 255;
+			useprint_color_z = readbyte() / 255;
+			useprint_colors[useprint_index] = useprint_color;
 			break;
 		case CSQC_EVENT_ROUNDCHANGE:
 			rounds = readbyte();

--- a/source/server/clientfuncs.qc
+++ b/source/server/clientfuncs.qc
@@ -102,16 +102,6 @@ void(float mode, entity to) ReportMapMode = {
 	multicast('0 0 0', MULTICAST_ONE);
 }
 
-void(entity to, float type, float cost, float weapon) useprint = {
-	WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
-	WriteByte(MSG_MULTICAST, CSQC_EVENT_USEPRINT);
-	WriteByte(MSG_MULTICAST, type);
-	WriteShort(MSG_MULTICAST, cost);
-	WriteByte(MSG_MULTICAST, weapon);
-	msg_entity = to;
-	multicast('0 0 0', MULTICAST_ONE);
-}
-
 void(string track_name) songegg =
 {
 	WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
@@ -653,16 +643,19 @@ float(entity them, entity me) PlayerIsLooking =
 	me.solid = SOLID_BBOX;
 	setorigin(me, me.origin);
 
-	vector source;
+	vector source, target;
 	makevectors (them.v_angle);
 	source = them.origin + them.view_ofs;
+	target = me.origin + (me.mins + me.maxs) * 0.5;
 
 	// Standard 'are we facing' test..
 	traceline(source, source + v_forward*50, 0, them);
 
 	// We're inside of an object.. is it the target?
 	if (trace_startsolid) {
-		if (v_forward*normalize(me.origin - them.origin) > 0.7)
+		// Brush entity origins are not necessarily inside their bounds (and are
+		// commonly the world origin), so face the bounds rather than me.origin.
+		if (v_forward*normalize(target - source) > 0.7)
 			ret = true;
 	} else if (trace_ent == me) {
 		ret = true;

--- a/source/server/defs/custom.qc
+++ b/source/server/defs/custom.qc
@@ -375,6 +375,18 @@ float zombie_spawn_points;
 .string wayTarget;
 .entity active_door;								// Set in waypoint mode
 .string targetname;									// the name of an entitys
+.string useprint_string_1;
+.string useprint_string_2;
+.string useprint_string_3;
+.string useprint_string_4;
+.vector useprint_color_1;
+.vector useprint_color_2;
+.vector useprint_color_3;
+.vector useprint_color_4;
+.float useprint_index_1;
+.float useprint_index_2;
+.float useprint_index_3;
+.float useprint_index_4;
 entity lastspawn;									// last spawn point used by spawning code
 .entity goaldummy; 									// Used to store the origin of the zombies target
 .float goalway; 									// Used to store the origin of the zombies target
@@ -560,7 +572,7 @@ float has_zone_file;
 .float x2_icon;
 .float insta_icon;
 .string	Weapon_Name;
-.string	Weapon_Name_Touch;
+.string	useprint_touch;
 
 #endif // FTE
 

--- a/source/server/defs/standard.qc
+++ b/source/server/defs/standard.qc
@@ -150,7 +150,7 @@ void            end_sys_globals;						// flag for structure dumping
 .vector         Flash_Offset;
 .float 			Flash_Size;
 .string			Weapon_Name;
-.string			Weapon_Name_Touch;
+.string			useprint_touch;
 .float          currentmag2;
 .float			viewmodel_effects;
 .float			viewmodel2_effects;
@@ -243,7 +243,7 @@ vector  (entity what)                                                           
 float   (entity zombie, entity target)                                                          Do_Pathfind_psp     = #84;
 void    (string s)                                                                              Open_Waypoint       = #85;
 vector  (entity zombie,vector start,vector min, vector max)                                     Get_Next_Waypoint   = #86;
-void    (entity client, float type, float cost, float weapon)                                   useprint            = #87;
+void    (entity client, float type, float cost)                                                 useprint            = #87;
 vector  (entity zombie,vector start,vector min, vector max)                                     Get_First_Waypoint  = #88;
 void    (string s)                                                                            	Close_Waypoint      = #89;
 void    (vector start, vector min, vector max, vector end, float nomonsters, entity forent)   	tracebox            = #90;
@@ -283,6 +283,7 @@ void    (float gamemode)                                                        
 void    (vector color)                                                                          nzp_setroundcolor   = #511;
 float   ()                                                                                      nzp_getmonthofyear  = #512;
 void    (float orientation)                                                                     nzp_setperkorientation = #513;
+void    (entity client, float index, string value, vector color)                                useprint_send       = #514;
 
 //
 // constants

--- a/source/server/dummies.qc
+++ b/source/server/dummies.qc
@@ -81,22 +81,6 @@ void() change_frame =
 	self.nextthink = time + 1;
 }
 
-#ifdef FTE
-
-void(void() spawnfunc) CheckSpawn =
-{
-  //do your own skill/deathmatch spawnflag checks here because the engine won't when this function exists
-  if (spawnfunc)
-    spawnfunc();
-  else
-  {
-    print(sprintf("no spawnfunc defined for %S\n", self.classname));
-    remove(self);
-  }
-};
-
-#endif // FTE
-
 #ifndef FTE
 
 void LoadWaypointData() = {};

--- a/source/server/entities/doors.qc
+++ b/source/server/entities/doors.qc
@@ -59,7 +59,7 @@ void() print_need_power =
 {
 	if(other.classname == "player" && !other.downed)
 	{
-		Player_UseprintWithWait(other, self, 8, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_3, 0);
 	}
 
 };
@@ -185,7 +185,7 @@ void() door_fire =
 		{
 			if(other.classname == "player" && !other.downed)
 			{
-				Player_UseprintWithWait(other, self, 8, 0, 0);
+				Player_UseprintWithWait(other, self, self.useprint_index_3, 0);
 				return;
 			}
 		}
@@ -247,7 +247,7 @@ if (self.state == STATE_TOP || self.state == STATE_UP)
 		{
 			if(other.classname == "player" && !other.downed)
 			{
-				Player_UseprintWithWait(other, self, 8, 0, 0);
+				Player_UseprintWithWait(other, self, self.useprint_index_3, 0);
 				return;
 			}
 		}
@@ -303,9 +303,9 @@ if (self.state == STATE_TOP || self.state == STATE_UP)
 		if(other.classname == "player" && !other.downed)
 		{
 			if (self.spawnflags & DOOR_DEBRIS)
-				Player_UseprintWithWait(other, self, 2, door_cost, 0);
+				Player_UseprintWithWait(other, self, self.useprint_index_2, door_cost);
 			else
-				Player_UseprintWithWait(other, self, 1, door_cost, 0);
+				Player_UseprintWithWait(other, self, self.useprint_index_1, door_cost);
 			return;
 		}
 	}	
@@ -565,6 +565,12 @@ void() func_door_model =
 void() func_door =
 
 {
+	if (!self.useprint_string_1) self.useprint_string_1 = "Hold %b to open Door";
+	if (!self.useprint_string_2) self.useprint_string_2 = "Hold %b to remove Debris";
+	if (!self.useprint_string_3) self.useprint_string_3 = "The Power must be Activated first";
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+	self.useprint_index_2 = Useprint_Register(self.useprint_string_2, self.useprint_color_2);
+	self.useprint_index_3 = Useprint_Register(self.useprint_string_3, self.useprint_color_3);
 
 	SetMovedir ();
 
@@ -626,6 +632,12 @@ void() func_door =
 
 void() func_door_nzp =
 {
+	if (!self.useprint_string_1) self.useprint_string_1 = "Hold %b to open Door";
+	if (!self.useprint_string_2) self.useprint_string_2 = "Hold %b to remove Debris";
+	if (!self.useprint_string_3) self.useprint_string_3 = "The Power must be Activated first";
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+	self.useprint_index_2 = Useprint_Register(self.useprint_string_2, self.useprint_color_2);
+	self.useprint_index_3 = Useprint_Register(self.useprint_string_3, self.useprint_color_3);
 
 #ifndef FTE
 

--- a/source/server/entities/func.qc
+++ b/source/server/entities/func.qc
@@ -438,7 +438,7 @@ void() touch_ending =
 
 	float ending_cost = floor(self.cost * game_modifier_cost_multiplier);
 	
-	Player_UseprintWithWait(other, self, 20, ending_cost, 0);
+	Player_UseprintWithWait(other, self, self.useprint_index_1, ending_cost);
 
 	if (Player_UseButtonPressed(other, self)) {
 
@@ -468,6 +468,8 @@ void() func_ending =
 		return;
 	//	objerror("ERROR: func_model expects a model. Removing.");
 
+	if (!self.useprint_string_1) self.useprint_string_1 = "Hold %b to End the Game";
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
 	precache_model (self.model);
 	
 	self.movetype = MOVETYPE_NONE;	// so it doesn't get pushed by anything

--- a/source/server/entities/mystery_box.qc
+++ b/source/server/entities/mystery_box.qc
@@ -695,11 +695,11 @@ void() MBOX_Touch =
 		return;
 		
 	if (!self.boxstatus) {
-		Player_UseprintWithWait(other, self, 6, mystery_box_cost, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_1, mystery_box_cost);
 	}
 	if (self.boxstatus == 2 && self.owner == other) {
-		other.Weapon_Name_Touch = GetWeaponName(self.boxweapon.weapon, -1);
-		Player_UseprintWithWait(other, self, 7, 0, self.boxweapon.weapon);
+		other.useprint_touch = GetWeaponName(self.boxweapon.weapon, -1);
+		Player_UseprintWithWait(other, self, self.useprint_index_2, 0);
 	}
 	
 	if (Player_UseButtonPressed(other, self) && !(other.semi_actions & SEMIACTION_USE))
@@ -1040,6 +1040,15 @@ void() mystery_box =
 	if (!self.powerup_vo) {
 		self.powerup_vo = "sounds/machines/mbox_close.wav";
 	}
+
+	if (!self.useprint_string_1) 
+		self.useprint_string_1 = "Hold %b for Mystery Box";
+	
+	if (!self.useprint_string_2)
+		self.useprint_string_2 = "Hold %b for %s";
+
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+	self.useprint_index_2 = Useprint_Register(self.useprint_string_2, self.useprint_color_2);
 
     // Store the custom presentation as globals
     mystery_box_model = self.model;

--- a/source/server/entities/pack_a_punch.qc
+++ b/source/server/entities/pack_a_punch.qc
@@ -273,7 +273,7 @@ void() PAP_Touch =
 	}
 
 	if (cvar("sv_magic") == 0) {
-		Player_UseprintWithWait(other, self, 21, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_4, 0);
 		return;
 	}
 
@@ -283,7 +283,7 @@ void() PAP_Touch =
     
 	// Power is not turned on.
 	if (self.requirespower == true && !isPowerOn) {
-		Player_UseprintWithWait(other, self, 8, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_3, 0);
 		return;
 	}
 
@@ -305,7 +305,7 @@ void() PAP_Touch =
 			return;
 		}
 
-		Player_UseprintWithWait(other, self, 12, pap_cost, 5);
+		Player_UseprintWithWait(other, self, self.useprint_index_1, pap_cost);
 
 		// Player has enough points, begin Upgrade process
 		if (other.points >= pap_cost && Player_UseButtonPressed(other, self) && other.weapon) {
@@ -321,8 +321,8 @@ void() PAP_Touch =
 
 	// Claiming upgraded Weapon
 	else if (self.papState == 2 && self.host == other) {
-		other.Weapon_Name_Touch = GetWeaponName(EqualPapWeapon(self.weapon), -1);
-		Player_UseprintWithWait(other, self, 7, 0, EqualPapWeapon(self.weapon));
+		other.useprint_touch = GetWeaponName(EqualPapWeapon(self.weapon), -1);
+		Player_UseprintWithWait(other, self, self.useprint_index_2, 0);
 
 		if (Player_UseButtonPressed(other, self)) {
  			entity tempe = self;
@@ -433,6 +433,23 @@ void() perk_pap =
 	if (!self.oldmodel) {
 		self.oldmodel = "sounds/machines/packapunch/upgrade.wav";
 	}
+
+	if (!self.useprint_string_1) 
+		self.useprint_string_1 = "Hold %b to Pack-a-Punch";
+
+	if (!self.useprint_string_2) 
+		self.useprint_string_2 = "Hold %b for %s";
+
+	if (!self.useprint_string_3) 
+		self.useprint_string_3 = "The Power must be Activated first";
+
+	if (!self.useprint_string_4)
+		self.useprint_string_4 = "...";
+	
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+	self.useprint_index_2 = Useprint_Register(self.useprint_string_2, self.useprint_color_2);
+	self.useprint_index_3 = Useprint_Register(self.useprint_string_3, self.useprint_color_3);
+	self.useprint_index_4 = Useprint_Register(self.useprint_string_4, self.useprint_color_4);
 
 	self.model = Compat_ConvertOldAssetPath(self.model);
 	self.weapon2model = Compat_ConvertOldAssetPath(self.weapon2model);

--- a/source/server/entities/perk_a_cola.qc
+++ b/source/server/entities/perk_a_cola.qc
@@ -267,23 +267,23 @@ void() touch_perk =
 		return;
 
 	if (cvar("sv_magic") == 0) {
-		useprint(other, 21, 0, 0);
+		useprint(other, self.useprint_index_2, 0);
 		return;
 	}
 
 	if (self.classname == "perk_juggernog" && cvar("sv_difficulty") == 3) {
-		useprint(other, 22, 0, 0);
+		useprint(other, self.useprint_index_3, 0);
 		return;
 	}
 
 	if (self.classname == "perk_revive" && cvar("sv_difficulty") == 3 && player_count == 1) {
-		useprint(other, 22, 0, 0);
+		useprint(other, self.useprint_index_3, 0);
 		return;
 	}
 	  
 	// Power's off! Nothing to do here.
 	if (self.requirespower == true && !isPowerOn) {
-		useprint(other, 8, 0, 0);
+		useprint(other, self.useprint_index_4, 0);
 		return;
 	}
 
@@ -315,7 +315,8 @@ void() touch_perk =
 		price = Gamemode_GetPerkMachinePrice(other, price);
 
 		// sequence = perk ID in client
-		Player_UseprintWithWait(other, self, 9, price, self.sequence);
+		other.useprint_touch = self.name;
+		Player_UseprintWithWait(other, self, self.useprint_index_1, price);
 
 		if (other.points >= price && Player_UseButtonPressed(other, self) && !(other.semi_actions & SEMIACTION_USE)) {
 			Player_RemoveScore(other, price);
@@ -494,8 +495,8 @@ void() setup_perk =
 // Perk-A-Cola Spawn functions.
 //
 void(string perk_classname,
-string default_model, float cost_solo, 
-float cost_coop, float light_spawnflag,
+string perk_name, string default_model,
+float cost_solo, float cost_coop, float light_spawnflag,
 float purchase_limit_solo, float purchase_limit_coop,
 float require_power_solo, float require_power_coop,
 float drink_skin, float perk_id) Perk_InitMachine =
@@ -503,6 +504,10 @@ float drink_skin, float perk_id) Perk_InitMachine =
 	//
 	// Set Default Stats for Compatibility
 	//
+
+	// Name
+	if (!self.name)
+		self.name = perk_name;
 
 	// Model
 	if (!self.model)
@@ -552,6 +557,21 @@ float drink_skin, float perk_id) Perk_InitMachine =
 	if (!self.perk_requires_power_coop)
 		self.perk_requires_power_coop = require_power_coop;
 
+	if (!self.useprint_string_1) 
+		self.useprint_string_1 = "Hold %b to buy %s";
+
+	if (!self.useprint_string_2) 
+		self.useprint_string_2 = "...";
+
+	if (!self.useprint_string_3) 
+		self.useprint_string_3 = "It doesn't seem to be working..";
+
+	if (!self.useprint_string_4) 
+		self.useprint_string_4 = "The Power must be Activated first";
+
+	if (!self.useprint_color_3) 
+		self.useprint_color_3 = '1 0 0';
+
 	// Precache if spawned naturally by the world.
 	if (time < 2) {
 		precache_model(self.model);
@@ -576,54 +596,58 @@ float drink_skin, float perk_id) Perk_InitMachine =
 	self.nextthink = time + 0.1;
 	self.sequence = drink_skin;
 	self.style = perk_id;
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+	self.useprint_index_2 = Useprint_Register(self.useprint_string_2, self.useprint_color_2);
+	self.useprint_index_3 = Useprint_Register(self.useprint_string_3, self.useprint_color_3);
+	self.useprint_index_4 = Useprint_Register(self.useprint_string_4, self.useprint_color_4);
 };
 
 // Quick Revive
 void() perk_revive =
 {
-	Perk_InitMachine("perk_revive", PERK_QUICKREVIVE_DEFAULT_MODEL, 500, 1500,
+	Perk_InitMachine("perk_revive", "Quick Revive", PERK_QUICKREVIVE_DEFAULT_MODEL, 500, 1500,
 	PERK_SPAWNFLAG_CYANLIGHT, 3, 1000, -1, true, 1, P_REVIVE);
 };
 
 // PhD Flopper
 void() perk_flopper =
 {
-	Perk_InitMachine("perk_flopper", PERK_PHDFLOPPER_DEFAULT_MODEL, 2000, 2000,
+	Perk_InitMachine("perk_flopper", "PhD Flopper", PERK_PHDFLOPPER_DEFAULT_MODEL, 2000, 2000,
 	PERK_SPAWNFLAG_YELLOWLIGHT, 1000, 1000, true, true, 6, P_FLOP);
 };
 
 // Jugger-Nog
 void() perk_juggernog =
 {
-	Perk_InitMachine("perk_juggernog", PERK_JUGGERNOG_DEFAULT_MODEL, 2500, 2500,
+	Perk_InitMachine("perk_juggernog", "Jugger-Nog", PERK_JUGGERNOG_DEFAULT_MODEL, 2500, 2500,
 	PERK_SPAWNFLAG_PINKLIGHT, 1000, 1000, true, true, 2, P_JUG);
 };
 
 // Stamin-Up
 void() perk_staminup =
 {
-	Perk_InitMachine("perk_staminup", PERK_STAMINUP_DEFAULT_MODEL, 2000, 2000,
+	Perk_InitMachine("perk_staminup", "Stamin-Up", PERK_STAMINUP_DEFAULT_MODEL, 2000, 2000,
 	PERK_SPAWNFLAG_YELLOWLIGHT, 1000, 1000, true, true, 5, P_STAMIN);
 };
 
 // Speed Cola
 void() perk_speed =
 {
-	Perk_InitMachine("perk_speed", PERK_SPEEDCOLA_DEFAULT_MODEL, 3000, 3000,
+	Perk_InitMachine("perk_speed", "Speed Cola", PERK_SPEEDCOLA_DEFAULT_MODEL, 3000, 3000,
 	PERK_SPAWNFLAG_LIMELIGHT, 1000, 1000, true, true, 3, P_SPEED);
 };
 
 // Double Tap Door Beer
 void() perk_double =
 {
-	Perk_InitMachine("perk_double", PERK_DOUBLETAP_DEFAULT_MODEL, 2000, 2000,
+	Perk_InitMachine("perk_double", "Double Tap Root Beer", PERK_DOUBLETAP_DEFAULT_MODEL, 2000, 2000,
 	PERK_SPAWNFLAG_YELLOWLIGHT, 1000, 1000, true, true, 4, P_DOUBLE);
 };
 
 // Deadshot Daiquiri
 void() perk_deadshot =
 {
-	Perk_InitMachine("perk_deadshot", PERK_DEADSHOT_DEFAULT_MODEL, 1500, 1500,
+	Perk_InitMachine("perk_deadshot", "Deadshot Daiquiri", PERK_DEADSHOT_DEFAULT_MODEL, 1500, 1500,
 	PERK_SPAWNFLAG_YELLOWLIGHT, 1000, 1000, true, true, 7, P_DEAD);
 };
 // naievil -- older maps compatability
@@ -632,7 +656,7 @@ void() perk_dead = { perk_deadshot();}
 // Mule Kick
 void() perk_mule =
 {
-	Perk_InitMachine("perk_mule", PERK_MULEKICK_DEFAULT_MODEL, 4000, 4000,
+	Perk_InitMachine("perk_mule", "Mule Kick", PERK_MULEKICK_DEFAULT_MODEL, 4000, 4000,
 	PERK_SPAWNFLAG_LIMELIGHT, 1000, 1000, true, true, 8, P_MULE);
 }
 

--- a/source/server/entities/power_switch.qc
+++ b/source/server/entities/power_switch.qc
@@ -90,7 +90,7 @@ void() Power_Touch =
 	entity tempe;
 	entity old_self;
 
-	Player_UseprintWithWait(other, self, 10, 0, 0);
+	Player_UseprintWithWait(other, self, self.useprint_index_1, 0);
 	if (Player_UseButtonPressed(other, self) && !isPowerOn) {
 
         // Animate the handle programmatically.
@@ -186,6 +186,9 @@ void() power_switch =
     if (self.powerup_vo != "")
         precache_sound(self.powerup_vo);
 
+	if (!self.useprint_string_1) 
+		self.useprint_string_1 = "Hold %b to Turn On the Power";
+
 	self.solid = SOLID_TRIGGER;
 	Precache_Set(self.model);
 	precache_sound(self.oldmodel);
@@ -193,6 +196,7 @@ void() power_switch =
 	setsize (self, VEC_HULL2_MIN, VEC_HULL2_MAX);
 	self.classname = "power_switch";
 	self.touch = Power_Touch;
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
 
     // Spawn the Handle
     if (!(self.spawnflags & POWER_SPAWNFLAG_NOHANDLE)) {

--- a/source/server/entities/teleporter.qc
+++ b/source/server/entities/teleporter.qc
@@ -198,12 +198,12 @@ void() teleport_pad_touch =
 		return;
 
 	if (!isPowerOn) {
-     	Player_UseprintWithWait(other, self, 8, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_2, 0);
     	return;
     } 
 
 	if (self.host.waitLink) {
-		Player_UseprintWithWait(other, self, 19, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_1, 0);
 
 		if (Player_UseButtonPressed(other, self)) {
 			self.host.isLinked = true;
@@ -212,7 +212,7 @@ void() teleport_pad_touch =
 		}
 	} else {
 		if (self.host.mode == 2) {
-			Player_UseprintWithWait(other, self, 18, 0, 0);
+			Player_UseprintWithWait(other, self, self.useprint_index_3, 0);
 		}
 	}
 }
@@ -221,7 +221,7 @@ void() teleporter_link_touch =
 {
 
 	if (!self.waitLink)
-		Player_UseprintWithWait(other, self, 17, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_4, 0);
 
 	if (Player_UseButtonPressed(other, self)) {
 		local entity en;
@@ -238,7 +238,7 @@ void() teleport_touch =
 	entity tempe;
 
 	if (self.cooldown) {
-		Player_UseprintWithWait(other, self, 16, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_3, 0);
 		return;
 	}
 
@@ -246,7 +246,7 @@ void() teleport_touch =
 		return;
   
   	if (!isPowerOn) {
-     	Player_UseprintWithWait(other, self, 8, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_2, 0);
     	return;
     } 
 
@@ -258,9 +258,9 @@ void() teleport_touch =
 	float teleporter_cost = floor(self.cost * game_modifier_cost_multiplier);
     
 	if (!self.cost)
-  		Player_UseprintWithWait(other, self, 14, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_1, 0);
 	else
-		Player_UseprintWithWait(other, self, 15, teleporter_cost, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_1, teleporter_cost);
 	
 
 	if (Player_UseButtonPressed(other, self) && !(other.semi_actions & SEMIACTION_USE)) {
@@ -347,6 +347,18 @@ void() func_teleporter_entrance =
         self.stance = 75;
     }
 
+	if (!self.useprint_string_1) 
+		self.useprint_string_1 = "Hold %b to use Teleporter";
+
+	if (!self.useprint_string_2) 
+		self.useprint_string_2 = "The Power must be Activated first";
+
+	if (!self.useprint_string_3) 
+		self.useprint_string_3 = "Teleporter is cooling down";
+
+	if (!self.useprint_string_4) 
+		self.useprint_string_4 = "Hold %b to initate link to pad";
+
     precache_model(self.model);
 	precache_model("models/sprites/lightning.spr");
 	precache_sound("sounds/machines/elec_shock.wav");
@@ -355,6 +367,10 @@ void() func_teleporter_entrance =
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_TRIGGER;
 	self.classname = "func_teleporter_entrance";
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+	self.useprint_index_2 = Useprint_Register(self.useprint_string_2, self.useprint_color_2);
+	self.useprint_index_3 = Useprint_Register(self.useprint_string_3, self.useprint_color_3);
+	self.useprint_index_4 = Useprint_Register(self.useprint_string_4, self.useprint_color_4);
   	setmodel(self, self.model);
   	setsize(self, VEC_HULL2_MIN, VEC_HULL2_MAX);
 	
@@ -408,6 +424,12 @@ void() func_teleporter_timed =
 //
 void() func_teleporter_pad =
 {
+	if (!self.useprint_string_1) self.useprint_string_1 = "Hold %b to link pad with core";
+	if (!self.useprint_string_2) self.useprint_string_2 = "The Power must be Activated first";
+	if (!self.useprint_string_3) self.useprint_string_3 = "Link not active";
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+	self.useprint_index_2 = Useprint_Register(self.useprint_string_2, self.useprint_color_2);
+	self.useprint_index_3 = Useprint_Register(self.useprint_string_3, self.useprint_color_3);
 	precache_model ("models/props/mainframe_pad.mdl");
 	precache_sound("sounds/weapons/tesla/switchon.wav");
 	

--- a/source/server/entities/traps.qc
+++ b/source/server/entities/traps.qc
@@ -236,14 +236,14 @@ void() zapper_touch =
 	}
 
 	if (self.requirespower == true && !isPowerOn) {
-		Player_UseprintWithWait (other, self, 8, 0, 0);
+		Player_UseprintWithWait (other, self, self.useprint_index_2, 0);
 		return;
 	}	
 
 	float trap_cost = floor(self.cost * game_modifier_cost_multiplier);
 
 	if (self.state == 0) {
-		Player_UseprintWithWait (other, self, 11, trap_cost, self.weapon);
+		Player_UseprintWithWait (other, self, self.useprint_index_1, trap_cost);
 
 		if (!Player_UseButtonPressed(other, self) || (other.semi_actions & SEMIACTION_USE)) {
 			return;
@@ -289,6 +289,16 @@ void() zapper_switch =
 	// Requires Power
 	if (self.spawnflags & TRAP_SPAWNFLAG_REQUIRESPOWER)
 		self.requirespower = true;
+
+	if (!self.useprint_string_1) 
+		self.useprint_string_1 = "Hold %b to Activate the Trap";
+
+	if (!self.useprint_string_2) 
+		self.useprint_string_2 = "The Power must be Activated first";
+
+
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+	self.useprint_index_2 = Useprint_Register(self.useprint_string_2, self.useprint_color_2);
 
     self.solid = SOLID_TRIGGER;
 	precache_model(self.model);

--- a/source/server/entities/triggers.qc
+++ b/source/server/entities/triggers.qc
@@ -231,10 +231,34 @@ void() trigger_interact_touch =
 	if (other.classname != "player" || other.downed || other.isBuying == true || !PlayerIsLooking(other, self))
 		return;
 
+	float interaction_cost = floor(self.cost * game_modifier_cost_multiplier);
+	if (self.useprint_index_1) {
+		Player_UseprintWithWait(other, self, self.useprint_index_1, interaction_cost);
+	}
+
 	if (Player_UseButtonPressed(other, self)) {
+		if (interaction_cost > 0 && other.points < interaction_cost) {
+			if (!(other.semi_actions & SEMIACTION_USE)) {
+				other.semi_actions |= SEMIACTION_USE;
+				centerprint(other, STR_NOTENOUGHPOINTS);
+				Sound_PlaySound(other, "sounds/misc/denybuy.wav", SOUND_TYPE_ENV_CHING, SOUND_PRIORITY_PLAYALWAYS);
+			}
+			return;
+		}
+
+		if (interaction_cost > 0)
+			Player_RemoveScore(other, interaction_cost);
+
 		if (self.noise != "")
 			Sound_PlaySound(other, self.noise, SOUND_TYPE_ENV_OBJECT, SOUND_PRIORITY_PLAYALWAYS);
-		multi_trigger();
+
+		self.enemy = other;
+		activator = other;
+		SUB_UseTargets();
+
+		// Keep the brush linked, but require another entity to fire us before
+		// accepting another player interaction.
+		self.touch = SUB_Null;
 	}
 }
 
@@ -245,15 +269,17 @@ void() trigger_interact_activate =
 
 void() trigger_interact =
 {
+	if (self.useprint_string_1 != "")
+		self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+
 	if (self.noise != "") {
 		precache_sound(self.noise);
 	}
 	
 	InitTrigger();
+	self.use = trigger_interact_activate;
 
-	if (self.spawnflags & SPAWNFLAG_TRIGGERINTERACT_STARTINACTIVE) {
-		self.use = trigger_interact_activate;
-	} else {
+	if (!(self.spawnflags & SPAWNFLAG_TRIGGERINTERACT_STARTINACTIVE)) {
 		self.touch = trigger_interact_touch;
 	}
 }

--- a/source/server/entities/wall_weapon.qc
+++ b/source/server/entities/wall_weapon.qc
@@ -150,7 +150,7 @@ void () WallWeapon_TouchTrigger =
 	}
 
 	if (self.weapon != 99) {
-		other.Weapon_Name_Touch = GetWeaponName(self.weapon, -1);
+		other.useprint_touch = GetWeaponName(self.weapon, -1);
 		float slot;
 
 		// Player has this weapon in any of their slots, PaP'd or not.
@@ -162,13 +162,11 @@ void () WallWeapon_TouchTrigger =
 			if (Weapon_PlayerHasWeapon(other, self.weapon, false) == slot)
 				is_pap = false;
 
-			// Set the cost and weapon value (for useprint).
+			// Set the ammo cost for the useprint.
 			wcost = (is_pap) ? self.pap_cost : self.cost2;
 			wcost = Gamemode_GetCostForWeaponAmmo(wcost, self.cost, other.weapons[slot].weapon_id, is_pap, other.weapons[slot - 1].weapon_tier);
 			wcost *= game_modifier_cost_multiplier;
-			float wep = (is_pap) ? EqualPapWeapon(self.weapon) : self.weapon;
-
-			Player_UseprintWithWait(other, self, 3, wcost, wep);
+			Player_UseprintWithWait(other, self, self.useprint_index_2, wcost);
 
 			if (!Player_UseButtonPressed(other, self) || (other.semi_actions & SEMIACTION_USE) || other.isBuying) {
 				return;
@@ -213,7 +211,7 @@ void () WallWeapon_TouchTrigger =
 	} else 
 	// Universal Ammo buy
 	{
-		other.Weapon_Name_Touch = GetWeaponName(other.weapon, -1);
+		other.useprint_touch = GetWeaponName(other.weapon, -1);
 
 		if (other.currentammo < getWeaponAmmo(other.weapon)) {
 
@@ -221,7 +219,7 @@ void () WallWeapon_TouchTrigger =
 			wcost = (IsPapWeapon(other.weapon)) ? self.pap_cost : self.cost2;
 			wcost *= game_modifier_cost_multiplier;
 
-			Player_UseprintWithWait(other, self, 3, wcost, other.weapon);
+			Player_UseprintWithWait(other, self, self.useprint_index_2, wcost);
 
 			if (!Player_UseButtonPressed(other, self) || (other.semi_actions & SEMIACTION_USE) || other.isBuying) {
 				return;
@@ -257,7 +255,7 @@ void () WallWeapon_TouchTrigger =
 
 		wcost = floor(self.cost * game_modifier_cost_multiplier);
 
-		Player_UseprintWithWait(other, self, 4, wcost, self.weapon);
+		Player_UseprintWithWait(other, self, self.useprint_index_1, wcost);
 
 		if (!Player_UseButtonPressed(other, self) || (other.semi_actions & SEMIACTION_USE))
 			return;
@@ -290,7 +288,7 @@ void () WallWeapon_TouchTrigger =
 	{
 		wcost = floor(self.cost2 * game_modifier_cost_multiplier);
 		if (other.primary_grenades < 4)
-			Player_UseprintWithWait(other, self, 3, wcost, self.weapon);
+			Player_UseprintWithWait(other, self, self.useprint_index_2, wcost);
 		else
 			return;
 		if (!Player_UseButtonPressed(other, self) || (other.semi_actions & SEMIACTION_USE))
@@ -322,7 +320,7 @@ void () WallWeapon_TouchTrigger =
 	{
 		wcost = floor(self.cost2 * game_modifier_cost_multiplier);
 		if (!other.has_bowie_knife) {
-			Player_UseprintWithWait(other, self, 4, wcost, self.weapon);
+			Player_UseprintWithWait(other, self, self.useprint_index_1, wcost);
 			if (Player_UseButtonPressed(other, self))
 			{
 				if (other.points < wcost) {
@@ -355,7 +353,7 @@ void () WallWeapon_TouchTrigger =
 		wcost = floor(self.cost * game_modifier_cost_multiplier);
 
 		//centerprint(other, self.message);
-      	Player_UseprintWithWait(other, self, 4, wcost, self.weapon);
+		Player_UseprintWithWait(other, self, self.useprint_index_1, wcost);
 
 		if (!Player_UseButtonPressed(other, self) || (other.semi_actions & SEMIACTION_USE)) {
 			return;
@@ -429,6 +427,10 @@ void() WallWeapon_EnableTouch =
 void() buy_weapon =
 {
 	InitTrigger ();
+	if (!self.useprint_string_1) self.useprint_string_1 = "Hold %b to buy %s";
+	if (!self.useprint_string_2) self.useprint_string_2 = "Hold %b to buy Ammo for %s";
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
+	self.useprint_index_2 = Useprint_Register(self.useprint_string_2, self.useprint_color_2);
 
 	// Default Pack-A-Punch Ammo Cost
 	if (!self.pap_cost)

--- a/source/server/entities/window.qc
+++ b/source/server/entities/window.qc
@@ -326,7 +326,7 @@ void() window_touch =
 		// cypress (09 dec 2023) -- support for limited barricade health.
 		if(self.health < self.health_delay)
 		{
-			Player_UseprintWithWait(other, self, 5, 0, 0);
+			Player_UseprintWithWait(other, self, self.useprint_index_1, 0);
 			
 			if(Player_UseButtonPressed(other, self))
 			{
@@ -382,6 +382,9 @@ void() item_barricade =
 		// Set Default Stats for Compatibility
 		//
 
+		if (!self.useprint_string_1) 
+			self.useprint_string_1 = "Hold %b to Rebuild Barrier";
+
 		// Model
 		if (!self.model)
 			self.model = "models/misc/window.mdl";
@@ -419,6 +422,7 @@ void() item_barricade =
 	self.classname = "window";
 	self.touch = window_touch;
 	self.solid = SOLID_TRIGGER;
+	self.useprint_index_1 = Useprint_Register(self.useprint_string_1, self.useprint_color_1);
 
 	if (self.health != -10) {
 		self.frame = Barricade_GetFrameForHealth(self.health);

--- a/source/server/fte_builtins.qc
+++ b/source/server/fte_builtins.qc
@@ -41,6 +41,33 @@ float NUM_FOR_EDICT(entity edict)
 }
 
 //
+// useprint_send(client, index, value, color)
+// Sends one registered useprint definition to a client.
+//
+void(entity client, float index, string value, vector color) useprint_send =
+{
+	WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
+	WriteByte(MSG_MULTICAST, CSQC_EVENT_REGISTERUSEPRINT);
+	WriteByte(MSG_MULTICAST, index);
+	WriteString(MSG_MULTICAST, value);
+	WriteByte(MSG_MULTICAST, color_x * 255);
+	WriteByte(MSG_MULTICAST, color_y * 255);
+	WriteByte(MSG_MULTICAST, color_z * 255);
+	msg_entity = client;
+	multicast('0 0 0', MULTICAST_ONE_R);
+};
+
+void(entity to, float index, float cost) useprint =
+{
+	WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
+	WriteByte(MSG_MULTICAST, CSQC_EVENT_USEPRINT);
+	WriteByte(MSG_MULTICAST, index);
+	WriteShort(MSG_MULTICAST, cost);
+	msg_entity = to;
+	multicast('0 0 0', MULTICAST_ONE);
+};
+
+//
 // nzp_achievement(client, achievement_id)
 // Awards achievement by sending approval to client.
 //

--- a/source/server/gamemodes/festive.qc
+++ b/source/server/gamemodes/festive.qc
@@ -28,9 +28,11 @@
 float festive_ran_post_init_logic;
 string festive_override_music;
 string festive_round_color;
+float festive_useprint_ammo;
 
 void() Gamemode_Festive_Init =
 {
+	festive_useprint_ammo = Useprint_Register("Hold %b to buy Ammo for %s", '1 1 1');
     precache_model(GetWeaponModel(W_BOWIE, false));
     precache_sound("sounds/modes/festive/rnd_splash.wav");
     precache_sound("sounds/modes/festive/rnd_start.wav");
@@ -99,10 +101,10 @@ void() Gamemode_Festive_AmmoCrateTouch =
     if (EqualNonPapWeapon(other.weapon) == W_RAY || EqualNonPapWeapon(other.weapon) == W_TESLA || EqualNonPapWeapon(other.weapon) == W_RAYMK2)
         ammo_cost = 10000;
 
-    other.Weapon_Name_Touch = GetWeaponName(other.weapon, -1);
+	other.useprint_touch = GetWeaponName(other.weapon, -1);
 
 	if (other.currentammo < getWeaponAmmo(other.weapon)) {
-		Player_UseprintWithWait(other, self, 3, ammo_cost, other.weapon);
+		Player_UseprintWithWait(other, self, self.useprint_index_1, ammo_cost);
 
 		if (!Player_UseButtonPressed(other, self) || (other.semi_actions & SEMIACTION_USE) || other.isBuying) {
 			return;
@@ -137,7 +139,8 @@ void(vector crate_origin, vector crate_angles) Gamemode_Festive_SpawnAmmoCrate =
     ammo_crate.angles = crate_angles;
     ammo_crate.scale = 2;
     ammo_crate.touch = Gamemode_Festive_AmmoCrateTouch;
-    ammo_crate.solid = SOLID_TRIGGER;
+	ammo_crate.solid = SOLID_TRIGGER;
+	ammo_crate.useprint_index_1 = festive_useprint_ammo;
     Light_Purple(ammo_crate);
 };
 

--- a/source/server/gamemodes/gun_game.qc
+++ b/source/server/gamemodes/gun_game.qc
@@ -38,6 +38,7 @@ float gungame_ran_post_init_logic;
 .float gungame_weapon_idx;
 .float gungame_score_threshold;
 .float gungame_update_time;
+float gungame_useprint_nuke;
 
 void() info_gungame_nukespot = {};
 
@@ -88,6 +89,7 @@ void() Gamemode_GunGame_GenerateWeaponList =
 
 void() Gamemode_GunGame_Init =
 {
+	gungame_useprint_nuke = Useprint_Register("Hold %b to Drop the Nuke", '1 1 1');
     // Create the list of Weapons to Cycle through.
     Gamemode_GunGame_GenerateWeaponList();
 
@@ -256,7 +258,7 @@ void() Gamemode_GunGame_NukeTouch =
     if (other != self.owner)
         return;
 
-    Player_UseprintWithWait(other, self, 23, 0, 0);
+	Player_UseprintWithWait(other, self, self.useprint_index_1, 0);
 
     if (Player_UseButtonPressed(other, self)) {
         // Flash the screen white
@@ -284,7 +286,8 @@ void() Gamemode_GunGame_SpawnNuke =
     setmodel(nuke_sparkle, "models/sprites/lightning.spr");
     nuke.solid = SOLID_TRIGGER;
     nuke.effects = EF_FULLBRIGHT;
-    nuke.owner = self;
+	nuke.owner = self;
+	nuke.useprint_index_1 = gungame_useprint_nuke;
 
     Light_Cyan(nuke_sparkle, true);
 

--- a/source/server/gamemodes/wild_west.qc
+++ b/source/server/gamemodes/wild_west.qc
@@ -29,9 +29,11 @@ float ww_ran_post_init_logic;
 float ww_inside_check_delay;
 
 .float ww_upgrade_tier;
+float ww_useprint_buy;
 
 void() Gamemode_WW_Init =
 {
+	ww_useprint_buy = Useprint_Register("Hold %b to buy %s", '1 1 1');
     // Disable All magic
     localcmd("sv_magic 0\n");
 
@@ -58,9 +60,10 @@ void() Gamemode_WW_NukeDrop =
     if (other.classname != "player" || other.downed)
         return;
 
-    float price = 5000;
+	float price = 5000;
 
-    Player_UseprintWithWait(other, self, 9, price, 9);
+	other.useprint_touch = self.name;
+	Player_UseprintWithWait(other, self, self.useprint_index_1, price);
 
     if (other.points >= price && Player_UseButtonPressed(other, self) && !(other.semi_actions & SEMIACTION_USE)) {
 		Player_RemoveScore(other, price);
@@ -77,9 +80,10 @@ void() Gamemode_WW_AmmoDrop =
     if (other.classname != "player" || other.downed)
         return;
 
-    float price = 5000;
+	float price = 5000;
 
-    Player_UseprintWithWait(other, self, 9, price, 12);
+	other.useprint_touch = self.name;
+	Player_UseprintWithWait(other, self, self.useprint_index_1, price);
 
     if (other.points >= price && Player_UseButtonPressed(other, self) && !(other.semi_actions & SEMIACTION_USE)) {
 		Player_RemoveScore(other, price);
@@ -96,9 +100,10 @@ void() Gamemode_WW_UpgrDrop =
     if (other.classname != "player" || other.downed)
         return;
 
-    float price = 5000;
+	float price = 5000;
 
-    Player_UseprintWithWait(other, self, 9, price, 11);
+	other.useprint_touch = self.name;
+	Player_UseprintWithWait(other, self, self.useprint_index_1, price);
 
     if (other.points >= price && Player_UseButtonPressed(other, self) && !(other.semi_actions & SEMIACTION_USE)) {
 		Player_RemoveScore(other, price);
@@ -113,9 +118,10 @@ void() Gamemode_WW_PerkDrop =
     if (other.classname != "player" || other.downed)
         return;
 
-    float price = 5000;
+	float price = 5000;
 
-    Player_UseprintWithWait(other, self, 9, price, 10);
+	other.useprint_touch = self.name;
+	Player_UseprintWithWait(other, self, self.useprint_index_1, price);
 
     if (other.points >= price && Player_UseButtonPressed(other, self) && !(other.semi_actions & SEMIACTION_USE)) {
 		Player_RemoveScore(other, price);
@@ -135,13 +141,21 @@ void() Gamemode_WW_SpawnTools =
     entity player_8_spawn = find(world, classname, "info_player_8_spawn");
 
     entity nuke_drop = spawn();
-    nuke_drop.classname = "ww_nuke_drop";
+	nuke_drop.classname = "ww_nuke_drop";
+	nuke_drop.name = "Nuke Drop";
     entity ammo_drop = spawn();
-    ammo_drop.classname = "ww_ammo_drop";
+	ammo_drop.classname = "ww_ammo_drop";
+	ammo_drop.name = "Ammo Drop";
     entity upgr_drop = spawn();
-    upgr_drop.classname = "ww_upgr_drop";
+	upgr_drop.classname = "ww_upgr_drop";
+	upgr_drop.name = "Damage Upgrade";
     entity perk_drop = spawn();
-    perk_drop.classname = "ww_perk_drop";
+	perk_drop.classname = "ww_perk_drop";
+	perk_drop.name = "Perk Drop";
+	nuke_drop.useprint_index_1 = ww_useprint_buy;
+	ammo_drop.useprint_index_1 = ww_useprint_buy;
+	upgr_drop.useprint_index_1 = ww_useprint_buy;
+	perk_drop.useprint_index_1 = ww_useprint_buy;
 
     entity nuke_sparkle = spawn();
     entity ammo_sparkle = spawn();

--- a/source/server/main.qc
+++ b/source/server/main.qc
@@ -353,10 +353,17 @@ void() precaches =
 	precache_sound("sounds/null.wav");
 }
 
+float useprint_revive;
+
 //called when map loaded
 void() worldspawn =
 {
 	precaches();
+
+	// Index zero is reserved for clearing the current prompt.
+	useprint_count = 1;
+	useprint_registration_locked = false;
+	useprint_revive = Useprint_Register("Hold %b to Revive Player", '1 1 1');
 
 	// Define all of our Light Styles
 	LS_Setup();
@@ -389,7 +396,7 @@ void() worldspawn =
 	clientstat(STAT_PERKS, EV_FLOAT, perks);
 	clientstat(STAT_TOTALSCORE, EV_FLOAT, score);
 	clientstat(STAT_WEAPONNAME, EV_STRING, Weapon_Name);
-	clientstat(STAT_WEAPONNAMETOUCH, EV_STRING, Weapon_Name_Touch);
+	clientstat(STAT_USEPRINTTOUCH, EV_STRING, useprint_touch);
 	clientstat(STAT_WEAPONTIER, EV_FLOAT, weapon_tier);
 	clientstat(STAT_VIEWMODEL_EFFECTS, EV_FLOAT, viewmodel_effects);
 	clientstat(STAT_VIEWMODEL2_EFFECTS, EV_FLOAT, viewmodel2_effects);
@@ -657,5 +664,25 @@ void() EndFrame =
 
 	if (cheats_have_been_activated == false && cvar("sv_cheats") == 1) {
 		cheats_have_been_activated = true;
+	}
+};
+
+void(void() spawnfunc) CheckSpawn =
+{
+	if (spawnfunc) {
+		if (cvar("developer")) {
+			dprint("CheckSpawn: running spawnfunc for ");
+			dprint(self.classname);
+			dprint("\n");
+		}
+
+		spawnfunc();
+	} else {
+		if (cvar("developer")) {
+			dprint("CheckSpawn: no spawnfunc defined for ");
+			dprint(self.classname);
+			dprint("\n");
+		}
+		remove(self);
 	}
 };

--- a/source/server/player/last_stand.qc
+++ b/source/server/player/last_stand.qc
@@ -387,7 +387,7 @@ void() LastStand_TouchReviveTrigger =
     // No one is actively reviving the downed team mate.
     if (self.owner.beingrevived == false) {
         // Hold F to revive...
-        Player_UseprintWithWait(other, self, 13, 0, 0);
+		Player_UseprintWithWait(other, self, self.useprint_index_1, 0);
 
         // Kick-off the revive sequence.
         if (Player_UseButtonPressed(other, self)) {
@@ -451,7 +451,8 @@ void(entity client) LastStand_SpawnReviveTrigger =
     revive_trigger.think = LastStand_ReviveTriggerFollow;
     revive_trigger.nextthink = time + 1;
     revive_trigger.touch = LastStand_TouchReviveTrigger;
-    revive_trigger.solid = SOLID_TRIGGER;
+	revive_trigger.solid = SOLID_TRIGGER;
+	revive_trigger.useprint_index_1 = useprint_revive;
     
     setorigin(revive_trigger, client.origin);
     setsize(revive_trigger, '-52 -52 -16', '52 52 -4');

--- a/source/server/player/player_core.qc
+++ b/source/server/player/player_core.qc
@@ -449,13 +449,13 @@ void() Player_UpdateProgressBar =
 };
 
 //
-// Player_UseprintWithWait(who, type, cost, weapon)
+// Player_UseprintWithWait(who, active_ent, useprint_index, cost)
 // For avoiding issues with overlapping bounding boxes for specific
 // machines.
 //
 .entity last_looked_ent;
 .float last_looked_time;
-void(entity who, entity active_ent, float type, float cost, float weapon) Player_UseprintWithWait =
+void(entity who, entity active_ent, float useprint_index, float cost) Player_UseprintWithWait =
 {
 	// Small delay before we can interact with a new entity to
 	// mitigate overlapping bboxes causing problems.
@@ -468,7 +468,7 @@ void(entity who, entity active_ent, float type, float cost, float weapon) Player
 	}
 
 	if (who.last_looked_ent == active_ent)
-		useprint(who, type, cost, weapon);
+		useprint(who, useprint_index, cost);
 };
 
 //
@@ -1086,7 +1086,7 @@ void() PlayerSpawn =
 		WorldText(world.chaptertitle, world.location, world.date, world.person, self);
 
 	ReportMapMode(map_compatibility_mode, self);
-
+	
 #else 
 
 	self.Flash_Offset = GetWeaponFlash_Offset(self.weapon);
@@ -1151,6 +1151,10 @@ void() SpectatorSpawn =
 float spawns_initialized;
 void() PutClientInServer =
 {
+	for (float i = 1; i < useprint_count; i++)
+		useprint_send(self, i, useprint_strings[i], useprint_colors[i]);
+	useprint_registration_locked = true;
+
 	// Init Spawn Points
 	if (!spawns_initialized) {
 		Spawns_Init();

--- a/source/server/tests/test_misc.qc
+++ b/source/server/tests/test_misc.qc
@@ -85,3 +85,139 @@ void() Test_Door_TriggeredCostDoorOpensOnce =
     remove(source);
     remove(door);
 };
+
+float test_trigger_interact_fire_count;
+void() Test_TriggerInteract_CountUse =
+{
+    test_trigger_interact_fire_count++;
+};
+
+//
+// Test_TriggerInteract_RequiresReactivation()
+// An interaction fires its targets and disables its touch handler. Another
+// trigger can then re-arm it so the player can fire its targets again.
+//
+void() Test_TriggerInteract_RequiresReactivation =
+{
+    entity trigger = spawn();
+	entity target_ent = spawn();
+    entity player = spawn();
+	entity old_self = self;
+	entity old_other = other;
+	entity old_activator = activator;
+	float old_cost_multiplier = game_modifier_cost_multiplier;
+	game_modifier_cost_multiplier = 1;
+
+    trigger.touch = trigger_interact_touch;
+    trigger.use = trigger_interact_activate;
+    trigger.target = "test_trigger_interact_target";
+	target_ent.targetname = trigger.target;
+	target_ent.use = Test_TriggerInteract_CountUse;
+	player.classname = "player";
+	player.button7 = true;
+	player.points = 1000;
+	trigger.cost = 250;
+    test_trigger_interact_fire_count = 0;
+
+    self = trigger;
+    other = player;
+    trigger.touch();
+
+    Test_Assert(test_trigger_interact_fire_count == 1, "Trigger interact did not fire its target!");
+    Test_Assert(trigger.touch == SUB_Null, "Trigger interact remained active after firing!");
+    Test_Assert(trigger.use == trigger_interact_activate, "Trigger interact lost its reactivation handler!");
+	Test_Assert(activator == player, "Trigger interact did not forward the player as activator!");
+	Test_Assert(player.points == 750, "Trigger interact did not deduct its cost!");
+
+    trigger.use();
+    Test_Assert(trigger.touch == trigger_interact_touch, "Trigger interact was not reactivated when fired!");
+
+    other = player;
+    trigger.touch();
+    Test_Assert(test_trigger_interact_fire_count == 2, "Reactivated trigger interact did not fire its target again!");
+	Test_Assert(trigger.touch == SUB_Null, "Trigger interact remained active after firing again!");
+	Test_Assert(player.points == 500, "Reactivated trigger interact did not deduct its cost exactly once!");
+
+    self = old_self;
+    other = old_other;
+	activator = old_activator;
+	game_modifier_cost_multiplier = old_cost_multiplier;
+    remove(player);
+	remove(target_ent);
+    remove(trigger);
+};
+
+void() Test_TriggerInteract_RejectsInsufficientFunds =
+{
+	entity trigger = spawn();
+	entity player = spawn();
+	entity old_self = self;
+	entity old_other = other;
+	float old_cost_multiplier = game_modifier_cost_multiplier;
+	game_modifier_cost_multiplier = 1;
+
+	trigger.touch = trigger_interact_touch;
+	trigger.cost = 500;
+	player.classname = "player";
+	player.button7 = true;
+	player.points = 499;
+	test_trigger_interact_fire_count = 0;
+
+	self = trigger;
+	other = player;
+	trigger.touch();
+
+	Test_Assert(test_trigger_interact_fire_count == 0, "Unaffordable trigger interact fired its targets!");
+	Test_Assert(player.points == 499, "Unaffordable trigger interact changed player points!");
+	Test_Assert(trigger.touch == trigger_interact_touch, "Unaffordable trigger interact disabled itself!");
+
+	self = old_self;
+	other = old_other;
+	game_modifier_cost_multiplier = old_cost_multiplier;
+	remove(player);
+	remove(trigger);
+};
+
+void() Test_TriggerInteract_RegistersOptionalUseprintWithCost =
+{
+	entity trigger = spawn();
+	entity old_self = self;
+	float old_count = useprint_count;
+	float old_lock = useprint_registration_locked;
+	useprint_registration_locked = false;
+	self = trigger;
+	self.cost = 750;
+	self.useprint_string_1 = "Hold %b to test interaction";
+
+	trigger_interact();
+
+	Test_Assert(self.useprint_string_1 == "Hold %b to test interaction", "Trigger interact replaced its mapper useprint!");
+	Test_Assert(self.useprint_index_1 != 0, "Trigger interact did not register its useprint!");
+	Test_Assert(self.cost == 750, "Trigger interact did not retain its optional cost!");
+
+	self = old_self;
+	useprint_count = old_count;
+	useprint_registration_locked = old_lock;
+	remove(trigger);
+};
+
+void() Test_TriggerInteract_DoesNotRegisterDefaultUseprint =
+{
+	entity trigger = spawn();
+	entity old_self = self;
+	float old_count = useprint_count;
+	float old_lock = useprint_registration_locked;
+	useprint_registration_locked = false;
+	self = trigger;
+
+	trigger_interact();
+
+	Test_Assert(self.useprint_string_1 == "", "Trigger interact created a default useprint!");
+	Test_Assert(self.useprint_index_1 == 0, "Trigger interact registered a missing useprint!");
+	Test_Assert(useprint_count == old_count, "A trigger without a useprint changed the registry!");
+
+	self = old_self;
+	useprint_count = old_count;
+	useprint_registration_locked = old_lock;
+	remove(trigger);
+};

--- a/source/server/tests/test_perksacola.qc
+++ b/source/server/tests/test_perksacola.qc
@@ -45,10 +45,29 @@ void() Test_Perks_QuickRevive_ValidateFields =
 
     Test_Assert((self.model == PERK_QUICKREVIVE_DEFAULT_MODEL), "Perk has incorrect model!");
     Test_Assert((self.cost == 500), "Perk has incorrect Solo cost!");
-    Test_Assert((self.cost2 == 1500), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.cost2 == 1500), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.name == "Quick Revive"), "Quick Revive has incorrect name!");
 
     self = old_self;
     remove(machine);
+};
+
+void() Test_Perks_NameOverridePreserved =
+{
+	entity machine = spawn();
+	entity old_self = self;
+	float old_lock = useprint_registration_locked;
+	useprint_registration_locked = false;
+	self = machine;
+	self.name = "Custom Name";
+
+	perk_revive();
+
+	Test_Assert((self.name == "Custom Name"), "Perk spawn replaced a mapper-defined name!");
+
+	self = old_self;
+	useprint_registration_locked = old_lock;
+	remove(machine);
 };
 
 // MARK: Jugger-Nog
@@ -68,7 +87,8 @@ void() Test_Perks_JuggerNog_ValidateFields =
 
     Test_Assert((self.model == PERK_JUGGERNOG_DEFAULT_MODEL), "Perk has incorrect model!");
     Test_Assert((self.cost == 2500), "Perk has incorrect Solo cost!");
-    Test_Assert((self.cost2 == 2500), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.cost2 == 2500), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.name == "Jugger-Nog"), "Jugger-Nog has incorrect name!");
 
     self = old_self;
     remove(machine);
@@ -91,7 +111,8 @@ void() Test_Perks_SpeedCola_ValidateFields =
 
     Test_Assert((self.model == PERK_SPEEDCOLA_DEFAULT_MODEL), "Perk has incorrect model!");
     Test_Assert((self.cost == 3000), "Perk has incorrect Solo cost!");
-    Test_Assert((self.cost2 == 3000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.cost2 == 3000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.name == "Speed Cola"), "Speed Cola has incorrect name!");
 
     self = old_self;
     remove(machine);
@@ -114,7 +135,8 @@ void() Test_Perks_DoubleTap_ValidateFields =
 
     Test_Assert((self.model == PERK_DOUBLETAP_DEFAULT_MODEL), "Perk has incorrect model!");
     Test_Assert((self.cost == 2000), "Perk has incorrect Solo cost!");
-    Test_Assert((self.cost2 == 2000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.cost2 == 2000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.name == "Double Tap Root Beer"), "Double Tap has incorrect name!");
 
     self = old_self;
     remove(machine);
@@ -137,7 +159,8 @@ void() Test_Perks_StaminUp_ValidateFields =
 
     Test_Assert((self.model == PERK_STAMINUP_DEFAULT_MODEL), "Perk has incorrect model!");
     Test_Assert((self.cost == 2000), "Perk has incorrect Solo cost!");
-    Test_Assert((self.cost2 == 2000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.cost2 == 2000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.name == "Stamin-Up"), "Stamin-Up has incorrect name!");
 
     self = old_self;
     remove(machine);
@@ -160,7 +183,8 @@ void() Test_Perks_PhDFlopper_ValidateFields =
 
     Test_Assert((self.model == PERK_PHDFLOPPER_DEFAULT_MODEL), "Perk has incorrect model!");
     Test_Assert((self.cost == 2000), "Perk has incorrect Solo cost!");
-    Test_Assert((self.cost2 == 2000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.cost2 == 2000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.name == "PhD Flopper"), "PhD Flopper has incorrect name!");
 
     self = old_self;
     remove(machine);
@@ -183,7 +207,8 @@ void() Test_Perks_DeadshotDaiquiri_ValidateFields =
 
     Test_Assert((self.model == PERK_DEADSHOT_DEFAULT_MODEL), "Perk has incorrect model!");
     Test_Assert((self.cost == 1500), "Perk has incorrect Solo cost!");
-    Test_Assert((self.cost2 == 1500), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.cost2 == 1500), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.name == "Deadshot Daiquiri"), "Deadshot has incorrect name!");
 
     self = old_self;
     remove(machine);
@@ -206,7 +231,8 @@ void() Test_Perks_MuleKick_ValidateFields =
 
     Test_Assert((self.model == PERK_MULEKICK_DEFAULT_MODEL), "Perk has incorrect model!");
     Test_Assert((self.cost == 4000), "Perk has incorrect Solo cost!");
-    Test_Assert((self.cost2 == 4000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.cost2 == 4000), "Perk has incorrect Co-Op cost!");
+	Test_Assert((self.name == "Mule Kick"), "Mule Kick has incorrect name!");
 
     self = old_self;
     remove(machine);

--- a/source/server/tests/test_useprints.qc
+++ b/source/server/tests/test_useprints.qc
@@ -1,0 +1,109 @@
+/*
+	server/tests/test_useprints.qc
+
+	Useprint registry tests.
+
+	Copyright (C) 2021-2026 NZ:P Team
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+	See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to:
+
+		Free Software Foundation, Inc.
+		59 Temple Place - Suite 330
+		Boston, MA  02111-1307, USA
+
+*/
+
+float(float condition, string message) Test_Assert;
+
+void() Test_Useprint_RegisterAllocatesDefinition =
+{
+	float old_count = useprint_count;
+	float old_lock = useprint_registration_locked;
+	useprint_registration_locked = false;
+
+	float index = Useprint_Register("test useprint allocation", '0 0 0');
+
+	Test_Assert(index == old_count, "Useprint was assigned the wrong index!");
+	Test_Assert(useprint_count == old_count + 1, "Useprint registry count was not incremented!");
+	Test_Assert(useprint_strings[index] == "test useprint allocation", "Useprint string was not stored!");
+	Test_Assert(useprint_colors[index] == '1 1 1', "An unspecified useprint color did not default to white!");
+
+	useprint_count = old_count;
+	useprint_registration_locked = old_lock;
+};
+
+void() Test_Useprint_RegisterDeduplicatesDefinition =
+{
+	float old_count = useprint_count;
+	float old_lock = useprint_registration_locked;
+	useprint_registration_locked = false;
+
+	float first = Useprint_Register("test useprint duplicate", '0.25 0.5 0.75');
+	float count_after_first = useprint_count;
+	float second = Useprint_Register("test useprint duplicate", '0.25 0.5 0.75');
+
+	Test_Assert(first == second, "Identical useprints received different indexes!");
+	Test_Assert(useprint_count == count_after_first, "A duplicate useprint grew the registry!");
+
+	useprint_count = old_count;
+	useprint_registration_locked = old_lock;
+};
+
+void() Test_Useprint_RegisterSeparatesColors =
+{
+	float old_count = useprint_count;
+	float old_lock = useprint_registration_locked;
+	useprint_registration_locked = false;
+
+	float white = Useprint_Register("test colored useprint", '1 1 1');
+	float red = Useprint_Register("test colored useprint", '1 0 0');
+
+	Test_Assert(white != red, "Differently colored useprints shared an index!");
+	Test_Assert(useprint_colors[white] == '1 1 1', "White useprint stored the wrong color!");
+	Test_Assert(useprint_colors[red] == '1 0 0', "Red useprint stored the wrong color!");
+
+	useprint_count = old_count;
+	useprint_registration_locked = old_lock;
+};
+
+void() Test_Useprint_GenericSlotsStoreIndexes =
+{
+	float old_count = useprint_count;
+	float old_lock = useprint_registration_locked;
+	useprint_registration_locked = false;
+
+	entity item = spawn();
+	item.useprint_string_1 = "test slot one %b";
+	item.useprint_string_2 = "test slot two %s";
+	item.useprint_string_3 = item.useprint_string_1;
+	item.useprint_color_2 = '0 1 0';
+
+	item.useprint_index_1 = Useprint_Register(item.useprint_string_1, item.useprint_color_1);
+	item.useprint_index_2 = Useprint_Register(item.useprint_string_2, item.useprint_color_2);
+	item.useprint_index_3 = Useprint_Register(item.useprint_string_3, item.useprint_color_3);
+
+	Test_Assert(item.useprint_index_1 != 0, "Generic useprint slot one was not registered!");
+	Test_Assert(item.useprint_index_2 != item.useprint_index_1, "Distinct generic slots shared an index!");
+	Test_Assert(item.useprint_index_3 == item.useprint_index_1, "Equivalent generic slots were not deduplicated!");
+
+	remove(item);
+	useprint_count = old_count;
+	useprint_registration_locked = old_lock;
+};
+
+void() Test_Useprint_RegistryLockedAfterClientJoin =
+{
+	Test_Assert(useprint_registration_locked, "Useprint registration was not locked before gameplay!");
+};

--- a/source/server/useprints.qc
+++ b/source/server/useprints.qc
@@ -1,0 +1,59 @@
+/*
+	server/map_rotation.qc
+
+	Global useprint definition registry.
+
+	Copyright (C) 2021-2026 NZ:P Team
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+	See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to:
+
+		Free Software Foundation, Inc.
+		59 Temple Place - Suite 330
+		Boston, MA  02111-1307, USA
+
+*/
+
+string useprint_strings[256];
+vector useprint_colors[256];
+float useprint_count;
+float useprint_registration_locked;
+
+float(string value, vector color) Useprint_Register =
+{
+	if (value == "")
+		return 0;
+
+	if (color == '0 0 0')
+		color = '1 1 1';
+
+	for (float i = 1; i < useprint_count; i++) {
+		if (useprint_strings[i] == value && useprint_colors[i] == color)
+			return i;
+	}
+
+	if (useprint_registration_locked)
+		error("Useprint_Register called after useprint registration was locked\n");
+
+	if (useprint_count > USEPRINT_MAX) {
+		dprint("WARNING: too many useprint strings\n");
+		return 0;
+	}
+
+	float index = useprint_count;
+	useprint_strings[index] = strzone(value);
+	useprint_colors[index] = color;
+	useprint_count++;
+	return index;
+};

--- a/source/shared/shared_defs.qc
+++ b/source/shared/shared_defs.qc
@@ -25,6 +25,8 @@
 
 */
 
+#define USEPRINT_MAX						255
+
 //
 // CSQC Particle Types
 //
@@ -54,9 +56,10 @@
 											// <byte> optional_field
 											// <entity> optional_entity
 
-#define CSQC_EVENT_USEPRINT				11	// <byte> useprint_type
+#define CSQC_EVENT_USEPRINT				11	// <byte> useprint index
 											// <short> useprint_cost
-											// <byte> useprint_weapon
+											// Definition placeholders:
+											// %b = bound use button, %s = useprint touch text
 
 #define CSQC_EVENT_ROUNDCHANGE			12	// <byte> round
 
@@ -88,20 +91,24 @@
 
 #define CSQC_EVENT_SETPERKMODE			22 	// <byte> orientation
 
-#define EVENT_UPDATE 					23
-#define EVENT_BLACKOUT 					24
-#define EVENT_WORLDDATA 				25
-#define EVENT_PLAYERUPDATE 				26
-#define EVENT_REVIVEON 					27
-#define EVENT_REVIVEOFF 				28
-#define EVENT_REVIVECHANGE 				29
-#define EVENT_WEAPONRECOIL 				30
-#define EVENT_GRENADEPULSE 				31
-#define EVENT_BETTYPROMPT 				32
-#define EVENT_CHATMESSAGE				33
-#define EVENT_DOUBLETAPUPDATE 			34
-#define EVENT_ENDGAME					35
-#define EVENT_MAPTYPE					36
+#define CSQC_EVENT_REGISTERUSEPRINT		23	// <byte> useprint index
+											// <string> useprint text
+											// <byte> red, green, blue
+
+#define EVENT_UPDATE 					24
+#define EVENT_BLACKOUT 					25
+#define EVENT_WORLDDATA 				26
+#define EVENT_PLAYERUPDATE 				27
+#define EVENT_REVIVEON 					28
+#define EVENT_REVIVEOFF 				29
+#define EVENT_REVIVECHANGE 				30
+#define EVENT_WEAPONRECOIL 				31
+#define EVENT_GRENADEPULSE 				32
+#define EVENT_BETTYPROMPT 				33
+#define EVENT_CHATMESSAGE				34
+#define EVENT_DOUBLETAPUPDATE 			35
+#define EVENT_ENDGAME					36
+#define EVENT_MAPTYPE					37
 
 //
 // Perk-A-Cola draw presets
@@ -342,7 +349,7 @@ float 	map_compatibility_mode;
 #define STAT_PERKS				69
 #define STAT_TOTALSCORE			70
 #define STAT_WEAPONNAME			71
-#define STAT_WEAPONNAMETOUCH	72
+#define STAT_USEPRINTTOUCH		72
 #define STAT_WEAPONTIER			73
 #define STAT_VIEWMODEL_EFFECTS  74
 #define STAT_VIEWMODEL2_EFFECTS 75

--- a/source/shared/weapon_stats.qc
+++ b/source/shared/weapon_stats.qc
@@ -243,39 +243,6 @@ string(float wep, float weapon_tier) GetWeaponName =
 }
 #endif
 
-string(float item) GetItemName =
-{
-	switch (item)
-	{
-		case 1:
-			return "Quick Revive";
-		case 2:
-			return "Juggernog";
-		case 3:
-			return "Speed Cola";
-		case 4:
-			return "Double Tap";
-		case 5:
-			return "Stamin-Up";
-		case 6:
-			return "PhD Flopper";
-		case 7:
-			return "Deadshot Daiquiri";
-		case 8:
-			return "Mule Kick";
-		case 9:
-			return "Nuke Drop";
-		case 10:
-			return "Perk Drop";
-		case 11:
-			return "Damage Upgrade";
-		case 12:
-			return "Ammo Drop";
-		default:
-			return "NULL";
-	}
-}
-
 float(float wep) GetFiretype =
 {
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
This completely refactors `useprint` to be driven by the server. The server controls the string, and it's color, and the placement of the interact icon etc. This was to facilitate an increase of functionality for `trigger_interact`, closes https://github.com/nzp-team/nzportable/issues/1489 . 
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A, see builds
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
