### PR TITLE
SERVER: Fix door rotation and door toggle-ing

### DIFF
--- a/source/server/entities/doors.qc
+++ b/source/server/entities/doors.qc
@@ -124,6 +124,10 @@ void() door_go_down =
 		self.isopen = 1;
 		return;//so we dont have to reopen doors
 	}
+
+	self.solid = SOLID_BSP;
+	setorigin(self, self.origin);
+
 	if (self.max_health)
 	{
 		self.takedamage = DAMAGE_YES;
@@ -319,7 +323,8 @@ void() door_use =
 
 	// Target chains can point back to an already-opening door.  Stop there so
 	// reciprocal door links do not recursively fire forever.
-	if (self.state == STATE_TOP || self.state == STATE_UP) {
+	if (self.state == STATE_UP ||
+		(self.state == STATE_TOP && !(self.spawnflags & DOOR_TOGGLE))) {
 		self = oself;
 		return;
 	}
@@ -441,6 +446,34 @@ entity(vector fmins, vector fmaxs) spawn_field =
 	t2 = fmaxs;
 	setsize (trigger, t1/* - '15 15 8'*/, t2/* + '15 15 8'*/);
 	return (trigger);
+};
+
+void() Door_SetupMovePositions =
+{
+	if (self.spawnflags & 256) {
+		self.pos1 = self.angles;
+		self.pos2 = self.pos1;
+		self.pos2_y = self.pos1_y + self.distance;
+	} else {
+		self.pos1 = self.origin;
+		self.pos2 = self.pos1 + self.movedir*(fabs(self.movedir*self.size) - self.lip);
+	}
+
+// DOOR_START_OPEN is to allow an entity to be lighted in the closed position
+// but spawn in the open position.
+	if (self.spawnflags & DOOR_START_OPEN)
+	{
+		if (self.spawnflags & 256)
+			self.angles = self.pos2;
+		else
+			setorigin (self, self.pos2);
+
+		self.pos2 = self.pos1;
+		if (self.spawnflags & 256)
+			self.pos1 = self.angles;
+		else
+			self.pos1 = self.origin;
+	}
 };
 
 
@@ -595,17 +628,7 @@ void() func_door =
 	if (!self.dmg)
 		self.dmg = 2;
 
-	self.pos1 = self.origin;
-	self.pos2 = self.pos1 + self.movedir*(fabs(self.movedir*self.size) - self.lip);
-
-// DOOR_START_OPEN is to allow an entity to be lighted in the closed position
-// but spawn in the open position
-	if (self.spawnflags & DOOR_START_OPEN)
-	{
-		setorigin (self, self.pos2);
-		self.pos2 = self.pos1;
-		self.pos1 = self.origin;
-	}
+	Door_SetupMovePositions();
 
 	self.state = STATE_BOTTOM;
 
@@ -696,24 +719,7 @@ void() func_door_nzp =
 	if (!self.dmg)
 		self.dmg = 2;
 
-	// only rotate on the Y axis.. potentially change?
-	if (self.spawnflags & 256) {
-		self.pos1 = self.angles;
-		self.pos2 = self.pos1;
-		self.pos2_y = self.pos1_y + self.distance;
-	} else {
-		self.pos1 = self.origin;
-		self.pos2 = self.pos1 + self.movedir*(fabs(self.movedir*self.size) - self.lip);
-	}
-
-// DOOR_START_OPEN is to allow an entity to be lighted in the closed position
-// but spawn in the open position
-	if (self.spawnflags & DOOR_START_OPEN)
-	{
-		setorigin (self, self.pos2);
-		self.pos2 = self.pos1;
-		self.pos1 = self.origin;
-	}
+	Door_SetupMovePositions();
 
 	self.state = STATE_BOTTOM;
 

--- a/source/server/tests/test_misc.qc
+++ b/source/server/tests/test_misc.qc
@@ -86,6 +86,101 @@ void() Test_Door_TriggeredCostDoorOpensOnce =
     remove(door);
 };
 
+//
+// Test_Door_RotatingUsesAnglesAndPreservesOrigin()
+// Verifies doors with the rotating spawnflag keeps its origin
+// and instead pivots when opened.
+// (https://github.com/nzp-team/nzportable/issues/908)
+//
+void() Test_Door_RotatingUsesAnglesAndPreservesOrigin =
+{
+	entity door = spawn();
+	entity old_self = self;
+
+	// Values from NZP_func_door.bsp.
+	door.origin = '52 -16 56';
+	door.angles = '0 0 0';
+	door.distance = 90;
+	door.spawnflags = 256;
+
+	self = door;
+	Door_SetupMovePositions();
+
+	Test_Assert(door.pos1 == '0 0 0', "Rotating door closed pose was not initialized from angles!");
+	Test_Assert(door.pos2 == '0 90 0', "Rotating door open pose did not use its angular distance!");
+	Test_Assert(door.origin == '52 -16 56', "Rotating door custom origin was moved!");
+
+	// A start-open rotating door must swap angle endpoints without moving its
+	// custom pivot.
+	door.angles = '0 0 0';
+	door.spawnflags = 256 | DOOR_START_OPEN;
+	Door_SetupMovePositions();
+
+	Test_Assert(door.angles == '0 90 0', "Start-open rotating door did not begin at its open angle!");
+	Test_Assert(door.pos1 == '0 90 0', "Start-open rotating door open pose was not swapped!");
+	Test_Assert(door.pos2 == '0 0 0', "Start-open rotating door closed pose was not swapped!");
+	Test_Assert(door.origin == '52 -16 56', "Start-open rotating door moved its custom origin!");
+
+	self = old_self;
+	remove(door);
+};
+
+//
+// Test_Door_ToggleCanCompleteMultipleCycles()
+// Verifies a door marked toggle-able can be opened, then closed,
+// then opened..
+// (https://github.com/nzp-team/nzportable/issues/1528)
+//
+void() Test_Door_ToggleCanCompleteMultipleCycles =
+{
+	entity door = spawn();
+	entity source = spawn();
+	entity old_self = self;
+	entity old_other = other;
+
+	door.owner = door;
+	door.enemy = door;
+	door.classname = "door";
+	door.spawnflags = DOOR_TOGGLE;
+	door.state = STATE_BOTTOM;
+	door.speed = 100;
+	door.wait = 3;
+	door.pos1 = '0 0 0';
+	door.pos2 = '10 0 0';
+
+	self = door;
+	other = source;
+
+	for (float cycle = 0; cycle < 2; cycle++) {
+		door_use();
+		Test_Assert(door.state == STATE_UP, "Toggle door did not begin opening!");
+
+		// Re-entry while opening must still be rejected.
+		door_use();
+		Test_Assert(door.state == STATE_UP, "Opening toggle door was activated recursively!");
+
+		setorigin(door, door.pos2);
+		door_hit_top();
+		Test_Assert(door.state == STATE_TOP, "Toggle door did not reach its open state!");
+
+		// Purchased doors become non-solid while open so the player can pass.
+		door.solid = SOLID_NOT;
+		door_use();
+		Test_Assert(door.state == STATE_DOWN, "Open toggle door did not begin closing!");
+		Test_Assert(door.solid == SOLID_BSP, "Closing toggle door did not restore BSP solidity!");
+
+		setorigin(door, door.pos1);
+		door_hit_bottom();
+		Test_Assert(door.state == STATE_BOTTOM, "Toggle door did not finish closing!");
+		Test_Assert(door.solid == SOLID_BSP, "Re-closed toggle door lost BSP solidity!");
+	}
+
+	self = old_self;
+	other = old_other;
+	remove(source);
+	remove(door);
+};
+
 float test_trigger_interact_fire_count;
 void() Test_TriggerInteract_CountUse =
 {


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Contains fixes for rotating `func_door`'s updating their origin instead of angles and for doors being toggle-able on and off.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---

https://github.com/user-attachments/assets/fc8f6e41-807c-446c-bb0a-f97dc1f58f5d


<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
