### PR TITLE
SERVER: Add game_random entity

### DIFF
--- a/progs/ssqc.src
+++ b/progs/ssqc.src
@@ -148,6 +148,7 @@ tests/test_power.qc
 tests/test_misc.qc
 tests/test_rounds.qc
 tests/test_game_counter.qc
+tests/test_game_random.qc
 tests/test_player.qc
 tests/test_teleporter.qc
 tests/test_useprints.qc

--- a/source/server/entities/map_entities.qc
+++ b/source/server/entities/map_entities.qc
@@ -514,7 +514,7 @@ void() info_changesky =
 void() game_random_use =
 {
 	float random_chance = floor(random() * self.health) + 1;
-	string selected_targetname = strzone(strcat(strcat(self.name), "_"), ftos(random_chance));
+	string selected_targetname = strzone(strcat(strcat(self.name, "_"), ftos(random_chance)));
 
 	self.target = selected_targetname;
 	SUB_UseTargets();

--- a/source/server/entities/map_entities.qc
+++ b/source/server/entities/map_entities.qc
@@ -508,3 +508,30 @@ void() info_changesky =
 	self.classname = "info_changesky";
 	self.use = info_changesky_use;
 };
+
+// MARK: game_random
+
+void() game_random_use =
+{
+	float random_chance = floor(random() * self.health) + 1;
+	string selected_targetname = strzone(strcat(strcat(self.name), "_"), ftos(random_chance));
+
+	self.target = selected_targetname;
+	SUB_UseTargets();
+	self.target = "";
+	strunzone(selected_targetname);
+};
+
+//
+// game_random()
+// Trigger-random-entity helper.
+//
+void() game_random =
+{
+	if (!self.health)
+		objerror("[ERROR]: game_random entity with no \"health\" (max answer)!\n");
+
+	if (!self.name)
+		objerror("[ERROR]: game_random entity with no \"name\" (target entities)!\n");
+	self.use = game_random_use;
+};

--- a/source/server/tests/test_game_random.qc
+++ b/source/server/tests/test_game_random.qc
@@ -1,0 +1,80 @@
+/*
+	server/tests/test_game_random.qc
+
+	Unit tests for game_random entity
+
+	Copyright (C) 2021-2026 NZ:P Team
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+	See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to:
+
+		Free Software Foundation, Inc.
+		59 Temple Place - Suite 330
+		Boston, MA  02111-1307, USA
+
+*/
+
+float(float condition, string message) Test_Assert;
+
+float test_game_random_fire_count;
+
+void() test_game_random_count_use =
+{
+	test_game_random_fire_count++;
+	self.frags++;
+};
+
+//
+// Test_game_random_FiresOneValidTargetPerUse()
+// Ensures every random result maps to a valid suffixed target and that the
+// temporary target value is cleared after use.
+//
+void() Test_game_random_FiresOneValidTargetPerUse =
+{
+	entity game_random_ent = spawn();
+	entity trigger = spawn();
+	entity old_self = self;
+	entity targets[8];
+	float i;
+
+	for (i = 0; i < 8; i++) {
+		targets[i] = spawn();
+		targets[i].targetname = sprintf("test_game_random_%d", i + 1);
+		targets[i].use = test_game_random_count_use;
+	}
+
+	self = game_random_ent;
+	self.health = 8;
+	self.name = "test_game_random";
+	self.targetname = "test_game_random_dispatcher";
+	game_random();
+	test_game_random_fire_count = 0;
+
+	self = trigger;
+	self.target = "test_game_random_dispatcher";
+	for (i = 0; i < 512; i++)
+		SUB_UseTargets();
+
+	Test_Assert(test_game_random_fire_count == 512, "game_random did not fire exactly one valid target per use!");
+	for (i = 0; i < 8; i++) {
+		Test_Assert(targets[i].frags > 0, sprintf("game_random never fired target %d!", i + 1));
+	}
+	Test_Assert(game_random_ent.target == "", "game_random did not clear its temporary target!");
+
+	self = old_self;
+	for (i = 0; i < 8; i++)
+		remove(targets[i]);
+	remove(trigger);
+	remove(game_random_ent);
+};


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Adds `game_random` entity, allowing a map to randomly execute one of X entities. Re-usable. Closes https://github.com/nzp-team/nzportable/issues/1532. Closes https://github.com/nzp-team/nzportable/issues/1536.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A, see builds
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
