### PR TITLE
Add support for button9 for cl_meleedive and more stance impulses

### DIFF
--- a/source/server/defs/standard.qc
+++ b/source/server/defs/standard.qc
@@ -112,6 +112,7 @@ void            end_sys_globals;						// flag for structure dumping
 .float 			button6;								//
 .float 			button7;								//
 .float 			button8;								//
+.float 			button9;								//
 .float          impulse;								// weapon changes
 .float          fixangle;
 .vector         v_angle;								// view / targeting angle for players

--- a/source/server/weapons/weapon_core.qc
+++ b/source/server/weapons/weapon_core.qc
@@ -1642,6 +1642,18 @@ void() Change_Stance = {
 
 }
 
+
+void() Change_StanceToggle =
+{
+	if (self.downed || !(self.flags & FL_ONGROUND) || self.changestance == true || self.new_ofs_z != self.view_ofs_z)
+		return;
+
+	if (self.stance == PLAYER_STANCE_STAND)
+		Player_SetStance(self, PLAYER_STANCE_CROUCH, true);
+	else if (Player_CanStandHere(self))
+		Player_SetStance(self, PLAYER_STANCE_STAND, true);
+};
+
 void() dolphin_dive =		//naievil
 {    
 	if (self.stance != 2)
@@ -1687,6 +1699,19 @@ void() dolphin_dive =		//naievil
 	self.oldz = self.origin_z;
 	Player_SetStance(self, PLAYER_STANCE_PRONE, false);
 }
+
+void() Change_StanceProne =
+{
+	if (self.downed || !(self.flags & FL_ONGROUND) || self.changestance == true || self.new_ofs_z != self.view_ofs_z)
+		return;
+
+	if (self.sprinting) {
+		dolphin_dive();
+		return;
+	}
+
+	Player_SetStance(self, PLAYER_STANCE_PRONE, true);
+};
 
 
 void () Impulse_Functions =
@@ -1747,6 +1772,12 @@ void () Impulse_Functions =
 				dolphin_dive();
 			else
 				Change_Stance();
+			break;
+		case 31:
+			Change_StanceToggle();
+			break;
+		case 32:
+			Change_StanceProne();
 			break;
 		case 100:
 			cvar_set("waypoint_mode", "1");
@@ -2151,7 +2182,7 @@ void() WeaponCore_MeleeButtonPressed =
 	// triggers Dive-to-Prone.
 #ifndef FTE
 
-	if (self.sprinting) {
+	if (self.sprinting && self.button9) {
 		dolphin_dive();
 		return;
 	}


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying component relevancy:
* `SERVER`: SSQC/Game code, for all supported platforms.
* `CLIENT`: CSQC for FTE, in the "client" directory.
* `MENU`: MenuQC

If commits generally are common, use the `GLOBAL` prefix.

Examples:
SERVER: Fixed runaway loop when loading mbox file
CLIENT: Adjusted round icon color on HUD
CLIENT/SERVER: Add new stat for revived player count

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
What it says on the tin
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
